### PR TITLE
make AssertionVisitor more overridable

### DIFF
--- a/lib/assertion-visitor.js
+++ b/lib/assertion-visitor.js
@@ -40,7 +40,7 @@ function AssertionVisitor (matcher, assertionPath, options) {
 }
 
 AssertionVisitor.prototype.enter = function (currentNode, parentNode) {
-    this.canonicalCode = generateCanonicalCode(currentNode, this.options.visitorKeys);
+    this.canonicalCode = this.generateCanonicalCode(currentNode);
     this.powerAssertCalleeObject = guessPowerAssertCalleeObjectFor(currentNode.callee);
 
     if (this.sourceMapConsumer) {
@@ -203,6 +203,29 @@ AssertionVisitor.prototype.toBeCaptured = function (currentNode, parentNode, cur
     return toBeCaptured(currentNode, parentNode, currentKey);
 };
 
+AssertionVisitor.prototype.generateCanonicalCode = function (node) {
+    var visitorKeys = this.options.visitorKeys;
+    var ast = espurifyWithRaw(node);
+    var visitor = {
+        leave: function (currentNode, parentNode) {
+            if (currentNode.type === syntax.Literal && typeof currentNode.raw !== 'undefined') {
+                currentNode['x-verbatim-espower'] = {
+                    content : currentNode.raw,
+                    precedence : escodegen.Precedence.Primary
+                };
+                return currentNode;
+            } else {
+                return undefined;
+            }
+        }
+    };
+    if (visitorKeys) {
+        visitor.keys = visitorKeys;
+    }
+    estraverse.replace(ast, visitor);
+    return escodegen.generate(ast, canonicalCodeOptions);
+};
+
 function fallbackOnBasename (filepath) {
     if (filepath) {
         if (filepath.split(_path.sep).indexOf('..') !== -1) {
@@ -224,28 +247,6 @@ function guessPowerAssertCalleeObjectFor (node) {
         return node.object; // Returns browser.assert when browser.assert.element(selector)
     }
     return null;
-}
-
-function generateCanonicalCode (node, visitorKeys) {
-    var ast = espurifyWithRaw(node);
-    var visitor = {
-        leave: function (currentNode, parentNode) {
-            if (currentNode.type === syntax.Literal && typeof currentNode.raw !== 'undefined') {
-                currentNode['x-verbatim-espower'] = {
-                    content : currentNode.raw,
-                    precedence : escodegen.Precedence.Primary
-                };
-                return currentNode;
-            } else {
-                return undefined;
-            }
-        }
-    };
-    if (visitorKeys) {
-        visitor.keys = visitorKeys;
-    }
-    estraverse.replace(ast, visitor);
-    return escodegen.generate(ast, canonicalCodeOptions);
 }
 
 function addLiteralTo (props, createNode, name, data) {

--- a/lib/assertion-visitor.js
+++ b/lib/assertion-visitor.js
@@ -41,7 +41,7 @@ function AssertionVisitor (matcher, assertionPath, options) {
 
 AssertionVisitor.prototype.enter = function (currentNode, parentNode) {
     this.canonicalCode = this.generateCanonicalCode(currentNode);
-    this.powerAssertCalleeObject = guessPowerAssertCalleeObjectFor(currentNode.callee);
+    this.powerAssertCalleeObject = this.guessPowerAssertCalleeObjectFor(currentNode.callee);
 
     if (this.sourceMapConsumer) {
         var pos = this.sourceMapConsumer.originalPositionFor({
@@ -226,6 +226,16 @@ AssertionVisitor.prototype.generateCanonicalCode = function (node) {
     return escodegen.generate(ast, canonicalCodeOptions);
 };
 
+AssertionVisitor.prototype.guessPowerAssertCalleeObjectFor = function (node) {
+    switch(node.type) {
+    case syntax.Identifier:
+        return node;
+    case syntax.MemberExpression:
+        return node.object; // Returns browser.assert when browser.assert.element(selector)
+    }
+    return null;
+};
+
 function fallbackOnBasename (filepath) {
     if (filepath) {
         if (filepath.split(_path.sep).indexOf('..') !== -1) {
@@ -237,16 +247,6 @@ function fallbackOnBasename (filepath) {
         }
     }
     return filepath;
-}
-
-function guessPowerAssertCalleeObjectFor (node) {
-    switch(node.type) {
-    case syntax.Identifier:
-        return node;
-    case syntax.MemberExpression:
-        return node.object; // Returns browser.assert when browser.assert.element(selector)
-    }
-    return null;
 }
 
 function addLiteralTo (props, createNode, name, data) {


### PR DESCRIPTION
make AssertionVisitor more overridable to help [Babel 6.x support of babel-plugin-espower](https://github.com/power-assert-js/babel-plugin-espower/pull/5)
