### PR TITLE
feat(espower): Instrument ES7 AwaitExpression Nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /build/escodegen.js
 /build/estraverse.js
 /build/assert.js
+/build/acorn-es7-plugin.js

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,6 +47,12 @@ var config = {
         destDir: './build',
         destName: 'source-map.js'
     },
+    acorn_es7_plugin_bundle: {
+        standalone: 'acornEs7Plugin',
+        require: 'acorn-es7-plugin',
+        destDir: './build',
+        destName: 'acorn-es7-plugin.js'
+    },
     coverage: {
         filename: 'coverage.lcov'
     },
@@ -57,7 +63,7 @@ var config = {
         browser: 'test/test-browser.html'
     }
 };
-var BUILDS = ['assert', 'escodegen', 'estraverse', 'source_map'];
+var BUILDS = ['assert', 'escodegen', 'estraverse', 'source_map', 'acorn_es7_plugin'];
 
 
 function captureStdout (filespec) {

--- a/lib/rules/supported-node-types.js
+++ b/lib/rules/supported-node-types.js
@@ -20,5 +20,6 @@ module.exports = [
     syntax.TaggedTemplateExpression,
     syntax.SpreadElement,
     syntax.YieldExpression,
+    syntax.AwaitExpression,
     syntax.Property
 ];

--- a/lib/rules/to-be-captured.js
+++ b/lib/rules/to-be-captured.js
@@ -17,6 +17,7 @@ var caputuringTargetTypes = [
     syntax.NewExpression,
     syntax.UpdateExpression,
     syntax.YieldExpression,
+    syntax.AwaitExpression,
     syntax.TemplateLiteral,
     syntax.TaggedTemplateExpression
 ];
@@ -33,14 +34,14 @@ function isChildOfTaggedTemplateExpression(parentNode) {
     return parentNode.type === syntax.TaggedTemplateExpression;
 }
 
-function isYieldArgument(parentNode, currentKey) {
-    // capture the yielded result, not the promise
-    return parentNode.type === syntax.YieldExpression && currentKey === 'argument';
+function isYieldOrAwaitArgument(parentNode, currentKey) {
+    // capture the yielded/await result, not the promise
+    return (parentNode.type === syntax.YieldExpression || parentNode.type === syntax.AwaitExpression) && currentKey === 'argument';
 }
 
 module.exports = function toBeCaptured (currentNode, parentNode, currentKey) {
     return isCaputuringTargetType(currentNode) &&
-        !isYieldArgument(parentNode, currentKey) &&
+        !isYieldOrAwaitArgument(parentNode, currentKey) &&
         !isCalleeOfParent(parentNode, currentKey) &&
         !isChildOfTaggedTemplateExpression(parentNode);
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "acorn": "^2.4.0",
+    "acorn-es7-plugin": "^1.0.7",
     "amdefine": "^1.0.0",
     "blanket": "^1.1.7",
     "browserify": "^11.1.0",

--- a/test/espower_option_test.js
+++ b/test/espower_option_test.js
@@ -1,25 +1,28 @@
 (function (root, factory) {
     'use strict';
     if (typeof define === 'function' && define.amd) {
-        define(['espower', 'acorn', 'escodegen', 'estraverse', 'source-map', 'assert'], factory);
+        define(['espower', 'acorn', 'acorn-es7-plugin', 'escodegen', 'estraverse', 'source-map', 'assert'], factory);
     } else if (typeof exports === 'object') {
-        factory(require('..'), require('acorn'), require('escodegen'), require('estraverse'), require('source-map'), require('assert'));
+        factory(require('..'), require('acorn'), require('acorn-es7-plugin'), require('escodegen'), require('estraverse'), require('source-map'), require('assert'));
     } else {
-        factory(root.espower, root.acorn, root.escodegen, root.estraverse, root.sourceMap, root.assert);
+        factory(root.espower, root.acorn, root.acornEs7Plugin, root.escodegen, root.estraverse, root.sourceMap, root.assert);
     }
 }(this, function (
     espower,
     acorn,
+    acornEs7Plugin,
     escodegen,
     estraverse,
     sourceMap,
     assert
 ) {
 
+acornEs7Plugin(acorn);
+
 var EspowerError = espower.EspowerError;
 
 function instrument (jsCode, options) {
-    var jsAST = acorn.parse(jsCode, {ecmaVersion: 6, locations: true});
+    var jsAST = acorn.parse(jsCode, {ecmaVersion: 7, locations: true, plugins: {asyncawait: true}});
     var espoweredAST = espower(jsAST, options);
     var instrumentedCode = escodegen.generate(espoweredAST, {format: {compact: true}});
     return instrumentedCode;

--- a/test/rjsconfig.js
+++ b/test/rjsconfig.js
@@ -4,6 +4,7 @@ var require = {
         assert: '../build/assert',
         escodegen: '../build/escodegen',
         acorn: '../node_modules/acorn/dist/acorn',
+        "acorn-es7-plugin": '../build/acorn-es7-plugin',
         estraverse: '../build/estraverse',
         "source-map": '../build/source-map',
         mocha: '../bower_components/mocha/mocha',

--- a/test/test-browser.html
+++ b/test/test-browser.html
@@ -11,6 +11,7 @@
     <div id="mocha"></div>
     <script type="text/javascript" src="../build/assert.js"></script>
     <script type="text/javascript" src="../node_modules/acorn/dist/acorn.js"></script>
+    <script type="text/javascript" src="../build/acorn-es7-plugin.js"></script>
     <script type="text/javascript" src="../build/estraverse.js"></script>
     <script type="text/javascript" src="../build/escodegen.js"></script>
     <script type="text/javascript" src="../build/espower.js"></script>


### PR DESCRIPTION
Employs `acorn-es7-plugin` to provide parsing.

async/await is [currently Stage 3 ("Candidate")](http://tc39.github.io/ecmascript-asyncawait/#status), and purports to be Stage 4 ("Finished") by the end of November.

It seems the [remaining questions](https://github.com/tc39/ecmascript-asyncawait#debatable-syntax--semantics) have to do with async function modifiers. We only care about AwaitExpressions, so it seems safe to implement now.