### PR TITLE
feat(espower): disambiguate between function calls and async/yield expressions

### DIFF
--- a/lib/assertion-visitor.js
+++ b/lib/assertion-visitor.js
@@ -28,7 +28,7 @@ function astEqual (ast1, ast2) {
     return deepEqual(espurify(ast1), espurify(ast2));
 }
 
-function AssertionVisitor (matcher, assertionPath, options) {
+function AssertionVisitor (matcher, assertionPath, enclosingFunc, options) {
     this.matcher = matcher;
     this.assertionPath = [].concat(assertionPath);
     this.options = options || {};
@@ -37,6 +37,8 @@ function AssertionVisitor (matcher, assertionPath, options) {
     }
     this.currentArgumentPath = null;
     this.argumentModified = false;
+    this.withinGenerator = enclosingFunc && enclosingFunc.generator;
+    this.withinAsync = enclosingFunc && enclosingFunc.async;
 }
 
 AssertionVisitor.prototype.enter = function (currentNode, parentNode) {
@@ -148,8 +150,14 @@ AssertionVisitor.prototype.captureArgument = function (node) {
     var n = newNodeWithLocationCopyOf(node);
     var props = [];
     var newCalleeObject = updateLocRecursively(espurify(this.powerAssertCalleeObject), n, this.options.visitorKeys);
+    if (this.withinAsync) {
+        addLiteralTo(props, n, 'async', true);
+    }
     addLiteralTo(props, n, 'content', this.canonicalCode);
     addLiteralTo(props, n, 'filepath', this.filepath);
+    if (this.withinGenerator) {
+        addLiteralTo(props, n, 'generator', true);
+    }
     addLiteralTo(props, n, 'line', this.lineNum);
     return n({
         type: syntax.CallExpression,

--- a/lib/instrumentor.js
+++ b/lib/instrumentor.js
@@ -37,7 +37,8 @@ Instrumentor.prototype.instrument = function (ast) {
                 var candidates = that.matchers.filter(function (matcher) { return matcher.test(currentNode); });
                 if (candidates.length === 1) {
                     // entering target assertion
-                    assertionVisitor = new AssertionVisitor(candidates[0], path, that.options);
+                    var enclosingFunc = findEnclosingFunction(controller.parents());
+                    assertionVisitor = new AssertionVisitor(candidates[0], path, enclosingFunc, that.options);
                     assertionVisitor.enter(currentNode, parentNode);
                     return undefined;
                 }
@@ -81,6 +82,23 @@ Instrumentor.prototype.instrument = function (ast) {
 
 function isCalleeOfParentCallExpression (parentNode, currentKey) {
     return parentNode.type === syntax.CallExpression && currentKey === 'callee';
+}
+
+function isFunction(node) {
+    return [
+          syntax.FunctionDeclaration,
+          syntax.FunctionExpression,
+          syntax.ArrowFunctionExpression
+      ].indexOf(node.type) !== -1;
+}
+
+function findEnclosingFunction(parents) {
+    for (var i = parents.length - 1; i >= 0; i--) {
+        if (isFunction(parents[i])) {
+            return parents[i];
+        }
+    }
+    return null;
 }
 
 function verifyAstPrerequisites (ast, options) {


### PR DESCRIPTION
In order to fully disambiguate the contextual keywords `async`
and `yield`, we need to pass along some additional context to
power-assert-formatter. Specifically whether the enclosing function
is async or a generator.

This adds two new properties to the context passed to `assert._expr()`

 - `async: true` if the function enclosing the assertion is an async function
 - `generator: true` if the function enclosing the assertion is a generator

In both cases, we do not set a property if the enclosing function is not
a generator/async (i.e. we never pass `async:false`). This is primarily
to avoid having to rewrite a bunch of existing unit tests.