### PR TITLE
Expose visitor object for estraverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ API
 * `options` argument is not valid
 
 
+### var visitor = espower.createVisitor(ast, [options])
+
+| return type |
+|:------------|
+| `object`    |
+
+`espower.createVisitor` generates visitor object to be used with `estraverse.replace`. Arguments are the same as `espower` function.
+
+
 #### ast
 
 | type     | default value |

--- a/index.js
+++ b/index.js
@@ -27,6 +27,11 @@ function espower (ast, options) {
     return instrumentor.instrument(ast);
 }
 
+espower.createVisitor = function (ast, options) {
+    var instrumentor = new Instrumentor(extend(defaultOptions(), options));
+    return instrumentor.createVisitor(ast);
+};
+
 espower.defaultOptions = defaultOptions;
 espower.Instrumentor = Instrumentor;
 espower.AssertionVisitor = require('./lib/assertion-visitor');

--- a/index.js
+++ b/index.js
@@ -15,11 +15,12 @@ var extend = require('xtend');
 
 /**
  * Instrument power assert feature into code. ECMAScript AST in, ECMAScript AST out.
+ *
  * @param {object} ast ECMAScript AST to be instrumented (directly modified)
  * @param {object} options Instrumentation options.
  * @returns {object} instrumented AST
- * @throws {EspowerError} if `originalAst` is already instrumented
- * @throws {EspowerError} if `originalAst` does not contain location information
+ * @throws {EspowerError} if `ast` is already instrumented
+ * @throws {EspowerError} if `ast` does not contain location information
  * @throws {EspowerError} if `options` is not valid
  */
 function espower (ast, options) {
@@ -27,7 +28,17 @@ function espower (ast, options) {
     return instrumentor.instrument(ast);
 }
 
-espower.createVisitor = function (ast, options) {
+/**
+ * Generate visitor object to be used with `estraverse.replace`
+ *
+ * @param {object} ast ECMAScript AST to be instrumented (directly modified)
+ * @param {object} options Instrumentation options.
+ * @returns {object} visitor object for estraverse
+ * @throws {EspowerError} if `ast` is already instrumented
+ * @throws {EspowerError} if `ast` does not contain location information
+ * @throws {EspowerError} if `options` is not valid
+ */
+espower.createVisitor = function createVisitor (ast, options) {
     var instrumentor = new Instrumentor(extend(defaultOptions(), options));
     return instrumentor.createVisitor(ast);
 };

--- a/lib/instrumentor.js
+++ b/lib/instrumentor.js
@@ -43,6 +43,10 @@ function Instrumentor (options) {
 }
 
 Instrumentor.prototype.instrument = function (ast) {
+    return estraverse.replace(ast, this.createVisitor(ast));
+};
+
+Instrumentor.prototype.createVisitor = function (ast) {
     verifyAstPrerequisites(ast, this.options);
     var that = this;
     var assertionVisitor;
@@ -126,7 +130,7 @@ Instrumentor.prototype.instrument = function (ast) {
     if (this.options.visitorKeys) {
         visitor.keys = this.options.visitorKeys;
     }
-    return estraverse.replace(ast, visitor);
+    return visitor;
 };
 
 function isCalleeOfParentCallExpression (parentNode, currentKey) {


### PR DESCRIPTION
`espower.createVisitor` generates visitor object to be used with `estraverse.replace`.
Arguments are the same as `espower` function.

Make it work with [merge-estraverse-visitors](https://github.com/twada/merge-estraverse-visitors) to integrate with [empower-assert](https://github.com/teppeis/empower-assert)

refs: #29
