### PR TITLE
Dealing with assertion that also is a concise body of ArrowFunctionExpression

### DIFF
--- a/lib/assertion-visitor.js
+++ b/lib/assertion-visitor.js
@@ -199,7 +199,8 @@ AssertionVisitor.prototype.verifyNotInstrumented = function (currentNode) {
 
 AssertionVisitor.prototype.createNewRecorder = function (controller) {
     var currentScope = this.options.currentScope;
-    var scopeBlockEspath = findEspathOfAncestorNode(currentScope.block, controller);
+    var currentBlock = findBlockedScope(currentScope).block;
+    var scopeBlockEspath = findEspathOfAncestorNode(currentBlock, controller);
     var recorderConstructorName = this.getRecorderConstructorName(controller);
     var recorderVariableName = this.options.transformation.generateUniqueName('rec');
 
@@ -342,6 +343,17 @@ function newNodeWithLocationCopyOf (original) {
         }
         return newNode;
     };
+}
+
+function findBlockedScope (scope) {
+    if (isArrowFunctionWithConciseBody(scope.block)) {
+        return findBlockedScope(scope.upper);
+    }
+    return scope;
+}
+
+function isArrowFunctionWithConciseBody (node) {
+    return node.type === 'ArrowFunctionExpression' && node.body.type !== 'BlockStatement';
 }
 
 function findEspathOfAncestorNode (targetNode, controller) {

--- a/test/fixtures/ArrowFunctionExpression/expected.js
+++ b/test/fixtures/ArrowFunctionExpression/expected.js
@@ -22,6 +22,7 @@ var _PowerAssertRecorder1 = function () {
     return PowerAssertRecorder;
 }();
 var _rec1 = new _PowerAssertRecorder1();
+var _rec2 = new _PowerAssertRecorder1();
 assert(v => v + 1);
 assert((v, i) => v + i);
 assert(v => ({
@@ -33,3 +34,16 @@ assert(_rec1._expr(_rec1._capt(_rec1._capt(seven, 'arguments/0/left') === _rec1.
     filepath: 'path/to/some_test.js',
     line: 9
 }));
+test('test name', () => assert(_rec2._expr(_rec2._capt(_rec2._capt(_rec2._capt(user, 'arguments/0/left/object').name, 'arguments/0/left') === 'Bob', 'arguments/0'), {
+    content: 'assert(user.name === \'Bob\')',
+    filepath: 'path/to/some_test.js',
+    line: 11
+})));
+test('promise', () => {
+    var _rec3 = new _PowerAssertRecorder1();
+    return Promise.resolve().then(() => assert(_rec3._expr(_rec3._capt(true === false, 'arguments/0'), {
+        content: 'assert(true === false)',
+        filepath: 'path/to/some_test.js',
+        line: 14
+    })));
+});

--- a/test/fixtures/ArrowFunctionExpression/fixture.js
+++ b/test/fixtures/ArrowFunctionExpression/fixture.js
@@ -7,3 +7,9 @@ assert((v, i) => v + i);
 assert(v => ({even: v, odd: v + 1}));
 
 assert(seven === ((v, i) => v + i)(four, five));
+
+test('test name', () => assert(user.name === 'Bob'));
+
+test('promise', () => {
+    return Promise.resolve().then(() => assert(true === false));
+});


### PR DESCRIPTION
Use upper block when assertion is a concise body of ArrowFunctionExpression.

fixes #33 