### PR TITLE
Fix: value recorder should clean up captured values on expression end

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,7 +87,7 @@ gulp.task('watch', function () {
 gulp.task('generate_recorder_json', function (done) {
     var filepath = path.join(__dirname, 'power-assert-recorder.js');
     var ast = acorn.parse(fs.readFileSync(filepath), { ecmaVersion: 6, locations: true });
-    var callexp = espurify(ast).body[0].expression;
+    var callexp = espurify(ast).body[0].expression.right;
     fs.writeFileSync(path.join(__dirname, 'lib', 'power-assert-recorder.json'), JSON.stringify(callexp, null, 2));
     done();
 });

--- a/lib/power-assert-recorder.json
+++ b/lib/power-assert-recorder.json
@@ -207,6 +207,52 @@
                 "type": "BlockStatement",
                 "body": [
                   {
+                    "type": "VariableDeclaration",
+                    "declarations": [
+                      {
+                        "type": "VariableDeclarator",
+                        "id": {
+                          "type": "Identifier",
+                          "name": "capturedValues"
+                        },
+                        "init": {
+                          "type": "MemberExpression",
+                          "object": {
+                            "type": "ThisExpression"
+                          },
+                          "property": {
+                            "type": "Identifier",
+                            "name": "captured"
+                          },
+                          "computed": false
+                        }
+                      }
+                    ],
+                    "kind": "var"
+                  },
+                  {
+                    "type": "ExpressionStatement",
+                    "expression": {
+                      "type": "AssignmentExpression",
+                      "operator": "=",
+                      "left": {
+                        "type": "MemberExpression",
+                        "object": {
+                          "type": "ThisExpression"
+                        },
+                        "property": {
+                          "type": "Identifier",
+                          "name": "captured"
+                        },
+                        "computed": false
+                      },
+                      "right": {
+                        "type": "ArrayExpression",
+                        "elements": []
+                      }
+                    }
+                  },
+                  {
                     "type": "ReturnStatement",
                     "argument": {
                       "type": "ObjectExpression",
@@ -242,15 +288,8 @@
                                   "name": "events"
                                 },
                                 "value": {
-                                  "type": "MemberExpression",
-                                  "object": {
-                                    "type": "ThisExpression"
-                                  },
-                                  "property": {
-                                    "type": "Identifier",
-                                    "name": "captured"
-                                  },
-                                  "computed": false
+                                  "type": "Identifier",
+                                  "name": "capturedValues"
                                 },
                                 "kind": "init",
                                 "method": false,

--- a/power-assert-recorder.js
+++ b/power-assert-recorder.js
@@ -1,4 +1,4 @@
-(function () {
+module.exports = (function () {
     function PowerAssertRecorder() {
         this.captured = [];
     }

--- a/power-assert-recorder.js
+++ b/power-assert-recorder.js
@@ -7,10 +7,12 @@ module.exports = (function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/espower_option_test.js
+++ b/test/espower_option_test.js
@@ -21,7 +21,7 @@ function rec(num) {
     return 'var _rec' + num + '=new _PowerAssertRecorder1();';
 }
 function prelude(num) {
-    var decl = "var _PowerAssertRecorder1=function(){function PowerAssertRecorder(){this.captured=[];}PowerAssertRecorder.prototype._capt=function _capt(value,espath){this.captured.push({value:value,espath:espath});return value;};PowerAssertRecorder.prototype._expr=function _expr(value,source){return{powerAssertContext:{value:value,events:this.captured},source:source};};return PowerAssertRecorder;}();";
+    var decl = "var _PowerAssertRecorder1=function(){function PowerAssertRecorder(){this.captured=[];}PowerAssertRecorder.prototype._capt=function _capt(value,espath){this.captured.push({value:value,espath:espath});return value;};PowerAssertRecorder.prototype._expr=function _expr(value,source){var capturedValues=this.captured;this.captured=[];return{powerAssertContext:{value:value,events:capturedValues},source:source};};return PowerAssertRecorder;}();";
     for (var i = 1; i <= num; i+=1) {
         decl += rec(i);
     }
@@ -274,7 +274,7 @@ describe('location information', function () {
 
 
 describe('lineSeparator', function () {
-    var lineDetected = "var _PowerAssertRecorder1=function(){function PowerAssertRecorder(){this.captured=[];}PowerAssertRecorder.prototype._capt=function _capt(value,espath){this.captured.push({value:value,espath:espath});return value;};PowerAssertRecorder.prototype._expr=function _expr(value,source){return{powerAssertContext:{value:value,events:this.captured},source:source};};return PowerAssertRecorder;}();var _rec1=new _PowerAssertRecorder1();var falsyStr='';assert.ok(_rec1._expr(_rec1._capt(falsyStr,'arguments/0'),{content:'assert.ok(falsyStr)',line:3}));";
+    var lineDetected = prelude(1) + "var falsyStr='';assert.ok(_rec1._expr(_rec1._capt(falsyStr,'arguments/0'),{content:'assert.ok(falsyStr)',line:3}));";
      function lineSeparatorTest (name, lineSeparatorInCode, options, expected) {
         it(name, function () {
             var sourceLines = [
@@ -336,7 +336,7 @@ describe('incoming SourceMap support', function () {
 
             var espoweredCode = escodegen.generate(espoweredAST, {format: {compact: true}});
 
-            var expectedOutput = "var _PowerAssertRecorder1=function(){function PowerAssertRecorder(){this.captured=[];}PowerAssertRecorder.prototype._capt=function _capt(value,espath){this.captured.push({value:value,espath:espath});return value;};PowerAssertRecorder.prototype._expr=function _expr(value,source){return{powerAssertContext:{value:value,events:this.captured},source:source};};return PowerAssertRecorder;}();var _rec1=new _PowerAssertRecorder1();var _rec2=new _PowerAssertRecorder1();var str='foo';var anotherStr='bar';assert.equal(_rec1._expr(_rec1._capt(str,'arguments/0'),{content:'assert.equal(str, anotherStr)',filepath:'" + opts.expectedPath + "',line:4}),_rec2._expr(_rec2._capt(anotherStr,'arguments/1'),{content:'assert.equal(str, anotherStr)',filepath:'" + opts.expectedPath + "',line:4}));";
+            var expectedOutput = prelude(2) + "var str='foo';var anotherStr='bar';assert.equal(_rec1._expr(_rec1._capt(str,'arguments/0'),{content:'assert.equal(str, anotherStr)',filepath:'" + opts.expectedPath + "',line:4}),_rec2._expr(_rec2._capt(anotherStr,'arguments/1'),{content:'assert.equal(str, anotherStr)',filepath:'" + opts.expectedPath + "',line:4}));";
             assert.equal(espoweredCode, expectedOutput);
         });
     }

--- a/test/fixtures/ArrayExpression/expected.js
+++ b/test/fixtures/ArrayExpression/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/ArrowFunctionExpression/expected.js
+++ b/test/fixtures/ArrowFunctionExpression/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/AssignmentExpression/expected.js
+++ b/test/fixtures/AssignmentExpression/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/AwaitExpression/expected.js
+++ b/test/fixtures/AwaitExpression/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/BinaryExpression/expected.js
+++ b/test/fixtures/BinaryExpression/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/CallExpression/expected.js
+++ b/test/fixtures/CallExpression/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/ConditionalExpression/expected.js
+++ b/test/fixtures/ConditionalExpression/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/FunctionExpression/expected.js
+++ b/test/fixtures/FunctionExpression/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/Identifier/expected.js
+++ b/test/fixtures/Identifier/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/Literal/expected.js
+++ b/test/fixtures/Literal/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/LogicalExpression/expected.js
+++ b/test/fixtures/LogicalExpression/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/MemberExpression/expected.js
+++ b/test/fixtures/MemberExpression/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/Mocha/expected.js
+++ b/test/fixtures/Mocha/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/NewExpression/expected.js
+++ b/test/fixtures/NewExpression/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/ObjectExpression/expected.js
+++ b/test/fixtures/ObjectExpression/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/Property/expected.js
+++ b/test/fixtures/Property/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/SequenceExpression/expected.js
+++ b/test/fixtures/SequenceExpression/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/SpreadElement/expected.js
+++ b/test/fixtures/SpreadElement/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/TaggedTemplateExpression/expected.js
+++ b/test/fixtures/TaggedTemplateExpression/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/TemplateLiteral/expected.js
+++ b/test/fixtures/TemplateLiteral/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/UnaryExpression/expected.js
+++ b/test/fixtures/UnaryExpression/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/UpdateExpression/expected.js
+++ b/test/fixtures/UpdateExpression/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/WithoutRequireAssert/expected.js
+++ b/test/fixtures/WithoutRequireAssert/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/WithoutUseStrict/expected.js
+++ b/test/fixtures/WithoutUseStrict/expected.js
@@ -10,10 +10,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/WithoutUseStrictNorRequireAssert/expected.js
+++ b/test/fixtures/WithoutUseStrictNorRequireAssert/expected.js
@@ -10,10 +10,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/fixtures/YieldExpression/expected.js
+++ b/test/fixtures/YieldExpression/expected.js
@@ -11,10 +11,12 @@ var _PowerAssertRecorder1 = function () {
         return value;
     };
     PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
         return {
             powerAssertContext: {
                 value: value,
-                events: this.captured
+                events: capturedValues
             },
             source: source
         };

--- a/test/instrumentation_test.js
+++ b/test/instrumentation_test.js
@@ -12,7 +12,7 @@ describe('instrumentation spec', function () {
         return 'var _rec' + num + '=new _PowerAssertRecorder1();';
     }
     function prelude(num) {
-        var decl = "var _PowerAssertRecorder1=function(){function PowerAssertRecorder(){this.captured=[];}PowerAssertRecorder.prototype._capt=function _capt(value,espath){this.captured.push({value:value,espath:espath});return value;};PowerAssertRecorder.prototype._expr=function _expr(value,source){return{powerAssertContext:{value:value,events:this.captured},source:source};};return PowerAssertRecorder;}();";
+        var decl = "var _PowerAssertRecorder1=function(){function PowerAssertRecorder(){this.captured=[];}PowerAssertRecorder.prototype._capt=function _capt(value,espath){this.captured.push({value:value,espath:espath});return value;};PowerAssertRecorder.prototype._expr=function _expr(value,source){var capturedValues=this.captured;this.captured=[];return{powerAssertContext:{value:value,events:capturedValues},source:source};};return PowerAssertRecorder;}();";
         for (var i = 1; i <= num; i+=1) {
             decl += rec(i);
         }

--- a/test/recorder_test.js
+++ b/test/recorder_test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var PowerAssertRecorder = require('../power-assert-recorder');
+var assert = require('assert');
+
+describe('power-assert-recorder', function () {
+    var foo = 'FOO';
+
+    it('_capt', function () {
+        var _rec = new PowerAssertRecorder();
+        var identVal = _rec._capt(foo, 'arguments/0');
+        assert.equal(identVal, 'FOO');
+    });
+
+    it('_expr', function () {
+        var _rec = new PowerAssertRecorder();
+        var capturedExpr = _rec._expr(_rec._capt(foo, 'arguments/0'), {
+            content: 'assert(foo)',
+            filepath: 'path/to/some_test.js',
+            line: 1
+        });
+        assert.deepEqual(capturedExpr, {
+            powerAssertContext: {
+                events: [
+                    {
+                        espath: "arguments/0",
+                        value: "FOO"
+                    }
+                ],
+                value: "FOO"
+            },
+            source: {
+                content: "assert(foo)",
+                filepath: "path/to/some_test.js",
+                line: 1
+            }
+        });
+    });
+});

--- a/test/recorder_test.js
+++ b/test/recorder_test.js
@@ -36,4 +36,34 @@ describe('power-assert-recorder', function () {
             }
         });
     });
+
+    it('repro case: recorder reused in loop', function () {
+        var _rec = new PowerAssertRecorder();
+        var expected = {
+            powerAssertContext: {
+                events: [
+                    {
+                        espath: "arguments/0",
+                        value: "FOO"
+                    }
+                ],
+                value: "FOO"
+            },
+            source: {
+                content: "assert(foo)",
+                filepath: "path/to/some_test.js",
+                line: 1
+            }
+        };
+        var actual;
+        for (var i = 0; i < 3; i += 1) {
+            actual = _rec._expr(_rec._capt(foo, 'arguments/0'), {
+                content: 'assert(foo)',
+                filepath: 'path/to/some_test.js',
+                line: 1
+            });
+            assert.deepEqual(actual, expected);
+        }
+    });
+
 });

--- a/test/recorder_test.js
+++ b/test/recorder_test.js
@@ -66,4 +66,72 @@ describe('power-assert-recorder', function () {
         }
     });
 
+    it('cleanup captured values on end', function () {
+        var incr = (function () {
+            var cnt = 0;
+            return function () {
+                return ++cnt;
+            };
+        })();
+        var _rec = new PowerAssertRecorder();
+        var actual = [];
+        for (var i = 0; i < 3; i += 1) {
+            actual.push(_rec._expr(_rec._capt(incr(), 'arguments/0'), {
+                content: 'assert(incr())',
+                filepath: 'path/to/some_test.js',
+                line: 1
+            }));
+        }
+        assert.deepEqual(actual, [
+            {
+                powerAssertContext: {
+                    events: [
+                        {
+                            espath: "arguments/0",
+                            value: 1
+                        }
+                    ],
+                    value: 1
+                },
+                source: {
+                    content: "assert(incr())",
+                    filepath: "path/to/some_test.js",
+                    line: 1
+                }
+            },
+            {
+                powerAssertContext: {
+                    events: [
+                        {
+                            espath: "arguments/0",
+                            value: 2
+                        }
+                    ],
+                    value: 2
+                },
+                source: {
+                    content: "assert(incr())",
+                    filepath: "path/to/some_test.js",
+                    line: 1
+                }
+            },
+            {
+                powerAssertContext: {
+                    events: [
+                        {
+                            espath: "arguments/0",
+                            value: 3
+                        }
+                    ],
+                    value: 3
+                },
+                source: {
+                    content: "assert(incr())",
+                    filepath: "path/to/some_test.js",
+                    line: 1
+                }
+            }
+        ]);
+    });
+
 });


### PR DESCRIPTION
Since recorder instances might be reused in loops.
For example, asserting loop invariants.
