### PR TITLE
fix: store scopes in a stack to push/pop them in a consistent way

### DIFF
--- a/lib/instrumentor.js
+++ b/lib/instrumentor.js
@@ -29,13 +29,14 @@ Instrumentor.prototype.createVisitor = function (ast) {
     var storage = {};
     var skipping = false;
     var scopeManager = escope.analyze(ast);
-    var currentScope = scopeManager.acquire(ast);
-    var globalScope = currentScope;
+    var globalScope = scopeManager.acquire(ast);
+    var scopeStack = [];
+    scopeStack.push(globalScope);
     var transformation = new Transformation();
     var visitor = {
         enter: function (currentNode, parentNode) {
             if (/Function/.test(currentNode.type)) {
-                currentScope = scopeManager.acquire(currentNode);
+                scopeStack.push(scopeManager.acquire(currentNode));
             }
             var controller = this;
             var path = controller.path();
@@ -56,7 +57,8 @@ Instrumentor.prototype.createVisitor = function (ast) {
                         storage: storage,
                         transformation: transformation,
                         globalScope: globalScope,
-                        currentScope: currentScope
+                        scopeManager: scopeManager,
+                        currentScope: scopeStack[scopeStack.length - 1]
                     }, that.options));
                     assertionVisitor.enter(controller);
                     return undefined;
@@ -98,7 +100,7 @@ Instrumentor.prototype.createVisitor = function (ast) {
                 return resultTree;
             } finally {
                 if (/Function/.test(currentNode.type)) {
-                    currentScope = currentScope.upper;
+                    scopeStack.pop();
                 }
             }
         }

--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -83,4 +83,5 @@ describe('fixtures', function () {
     testTransform('SpreadElement');
     testTransform('YieldExpression');
     testTransform('AwaitExpression');
+    testTransform('ClassScope');
 });

--- a/test/fixtures/ClassScope/expected.js
+++ b/test/fixtures/ClassScope/expected.js
@@ -1,0 +1,38 @@
+'use strict';
+var _PowerAssertRecorder1 = function () {
+    function PowerAssertRecorder() {
+        this.captured = [];
+    }
+    PowerAssertRecorder.prototype._capt = function _capt(value, espath) {
+        this.captured.push({
+            value: value,
+            espath: espath
+        });
+        return value;
+    };
+    PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
+        return {
+            powerAssertContext: {
+                value: value,
+                events: capturedValues
+            },
+            source: source
+        };
+    };
+    return PowerAssertRecorder;
+}();
+var _rec1 = new _PowerAssertRecorder1();
+const assert = require('assert');
+class Dog {
+    say() {
+        return 'bow';
+    }
+}
+const d = new Dog();
+assert(_rec1._expr(_rec1._capt(_rec1._capt(d, 'arguments/0/callee/object').say(), 'arguments/0'), {
+    content: 'assert(d.say())',
+    filepath: 'path/to/some_test.js',
+    line: 12
+}));

--- a/test/fixtures/ClassScope/fixture.js
+++ b/test/fixtures/ClassScope/fixture.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const assert = require('assert');
+
+class Dog {
+    say() {
+        return 'bow';
+    }
+}
+
+const d = new Dog();
+assert(d.say());


### PR DESCRIPTION
Parent scope does not match parent function scope on leaving class
since espower handles scopes only at function level.

```js
const assert = require('assert');
class Dog {
    say() {
        return 'bow';
        // gap occurs here
    }
}
const d = new Dog();
assert(d.say());
```

refs: power-assert-js/power-assert#78
refs: power-assert-js/power-assert#79
