### PR TITLE
Add `ecmaVersion` and `sourceType` to options to support ES Modules syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Returns default options object for `espower` function. In other words, returns
 
 ```javascript
 {
+    ecmaVersion: 2016,
+    sourceType: 'module',
     patterns: [
         'assert(value, [message])',
         'assert.ok(value, [message])',

--- a/README.md
+++ b/README.md
@@ -101,6 +101,24 @@ If callee name (for example, `assert.equal`) matches exactly and number of argum
 Detection is done by [escallmatch](https://github.com/twada/escallmatch). Any arguments enclosed in bracket (for example, `[message]`) means optional parameters. Without bracket means mandatory parameters.
 
 
+#### options.ecmaVersion
+
+| type     | default value |
+|:---------|:--------------|
+| `number` | `2016`        |
+
+The ECMAScript version to parse and analyze. Must be either 3, 5, 6 (2015), 2016, or 2017.
+
+
+#### options.sourceType
+
+| type     | default value |
+|:---------|:--------------|
+| `string` | `'module'`    |
+
+The source type of the code. Must be either `"script"` or `"module"`.
+
+ 
 #### (optional) options.path
 
 | type     | default value |

--- a/lib/assertion-visitor.js
+++ b/lib/assertion-visitor.js
@@ -198,8 +198,7 @@ AssertionVisitor.prototype.verifyNotInstrumented = function (currentNode) {
 };
 
 AssertionVisitor.prototype.createNewRecorder = function (controller) {
-    var currentScope = this.options.currentScope;
-    var currentBlock = findBlockedScope(currentScope).block;
+    var currentBlock = findBlockedScope(this.options.scopeStack).block;
     var scopeBlockEspath = findEspathOfAncestorNode(currentBlock, controller);
     var recorderConstructorName = this.getRecorderConstructorName(controller);
     var recorderVariableName = this.options.transformation.generateUniqueName('rec');
@@ -345,9 +344,11 @@ function newNodeWithLocationCopyOf (original) {
     };
 }
 
-function findBlockedScope (scope) {
-    if (isArrowFunctionWithConciseBody(scope.block)) {
-        return findBlockedScope(scope.upper);
+function findBlockedScope (scopeStack) {
+    var lastIndex = scopeStack.length - 1;
+    var scope = scopeStack[lastIndex];
+    if (!scope.block || isArrowFunctionWithConciseBody(scope.block)) {
+        return findBlockedScope(scopeStack.slice(0, lastIndex));
     }
     return scope;
 }

--- a/lib/default-options.js
+++ b/lib/default-options.js
@@ -2,6 +2,8 @@
 
 module.exports = function defaultOptions () {
     return {
+        ecmaVersion: 2016,
+        sourceType: 'module',
         patterns: [
             'assert(value, [message])',
             'assert.ok(value, [message])',

--- a/lib/instrumentor.js
+++ b/lib/instrumentor.js
@@ -64,8 +64,7 @@ Instrumentor.prototype.createVisitor = function (ast) {
                         storage: storage,
                         transformation: transformation,
                         globalScope: globalScope,
-                        scopeManager: scopeManager,
-                        currentScope: scopeStack[scopeStack.length - 1]
+                        scopeStack: scopeStack
                     }, that.options));
                     assertionVisitor.enter(controller);
                     return undefined;

--- a/lib/instrumentor.js
+++ b/lib/instrumentor.js
@@ -28,7 +28,14 @@ Instrumentor.prototype.createVisitor = function (ast) {
     var assertionVisitor;
     var storage = {};
     var skipping = false;
-    var scopeManager = escope.analyze(ast);
+    var escopeOptions = {
+        ecmaVersion: this.options.ecmaVersion,
+        sourceType: this.options.sourceType
+    };
+    if (this.options.visitorKeys) {
+        escopeOptions.childVisitorKeys = this.options.visitorKeys;
+    }
+    var scopeManager = escope.analyze(ast, escopeOptions);
     var globalScope = scopeManager.acquire(ast);
     var scopeStack = [];
     scopeStack.push(globalScope);

--- a/test/espower_option_test.js
+++ b/test/espower_option_test.js
@@ -35,6 +35,12 @@ describe('espower.defaultOptions()', function () {
     it('destructive: undefined', function () {
         assert.equal(this.options.destructive, undefined);
     });
+    it('ecmaVersion: 2016', function () {
+        assert.equal(this.options.ecmaVersion, 2016);
+    });
+    it('sourceType: "module"', function () {
+        assert.equal(this.options.sourceType, 'module');
+    });
     it('patterns: Array', function () {
         assert.deepEqual(this.options.patterns, [
             'assert(value, [message])',

--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -84,4 +84,5 @@ describe('fixtures', function () {
     testTransform('YieldExpression');
     testTransform('AwaitExpression');
     testTransform('ClassScope');
+    testTransform('Scopes');
 });

--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -19,7 +19,7 @@ function testWithParser (fixtureName, parse, manipulate) {
         var actualFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'actual.js');
 
         var jsAST = parse(fixtureFilepath);
-        var espoweredAST = manipulate(jsAST, {path: 'path/to/some_test.js'});
+        var espoweredAST = manipulate(jsAST, {ecmaVersion: 2017, path: 'path/to/some_test.js'});
         var output = escodegen.generate(espoweredAST);
 
         var actual = output + '\n';
@@ -33,7 +33,7 @@ function testWithParser (fixtureName, parse, manipulate) {
 
 function testTransform (fixtureName, extraOptions) {
     function by_acorn (filepath) {
-        var parserOptions = {ecmaVersion: 7, locations: true, plugins: {asyncawait: true}};
+        var parserOptions = {ecmaVersion: 2017, locations: true, plugins: {asyncawait: true}};
         return acorn.parse(fs.readFileSync(filepath, 'utf8'), parserOptions);
     }
     function by_esprima (filepath) {

--- a/test/fixtures/Scopes/expected.js
+++ b/test/fixtures/Scopes/expected.js
@@ -1,0 +1,42 @@
+var _PowerAssertRecorder1 = function () {
+    function PowerAssertRecorder() {
+        this.captured = [];
+    }
+    PowerAssertRecorder.prototype._capt = function _capt(value, espath) {
+        this.captured.push({
+            value: value,
+            espath: espath
+        });
+        return value;
+    };
+    PowerAssertRecorder.prototype._expr = function _expr(value, source) {
+        var capturedValues = this.captured;
+        this.captured = [];
+        return {
+            powerAssertContext: {
+                value: value,
+                events: capturedValues
+            },
+            source: source
+        };
+    };
+    return PowerAssertRecorder;
+}();
+var _rec1 = new _PowerAssertRecorder1();
+var _rec2 = new _PowerAssertRecorder1();
+var assert = require('assert');
+for (var i = 0; i < 3; i += 1) {
+    if (foo) {
+        assert(_rec1._expr(_rec1._capt(_rec1._capt(foo, 'arguments/0/left') === 'FOO', 'arguments/0'), {
+            content: 'assert(foo === \'FOO\')',
+            filepath: 'path/to/some_test.js',
+            line: 5
+        }));
+    } else {
+        assert(_rec2._expr(_rec2._capt(bar, 'arguments/0'), {
+            content: 'assert(bar)',
+            filepath: 'path/to/some_test.js',
+            line: 7
+        }));
+    }
+}

--- a/test/fixtures/Scopes/fixture.js
+++ b/test/fixtures/Scopes/fixture.js
@@ -1,0 +1,9 @@
+var assert = require('assert');
+
+for (var i = 0; i < 3; i += 1) {
+    if (foo) {
+        assert(foo === 'FOO');
+    } else {
+        assert(bar);
+    }
+}


### PR DESCRIPTION
Add `ecmaVersion` and `sourceType` to options, with their sensible defaults.
These two options are used by `escope` to support ES Modules syntax

refs power-assert-js/espower-source#15