### PR TITLE
Skip modifying argument if SpreadElement appears immediately beneath assert

### DIFF
--- a/lib/instrumentor.js
+++ b/lib/instrumentor.js
@@ -9,6 +9,9 @@ var Transformation = require('./transformation');
 var EspowerError = require('./espower-error');
 var typeName = require('type-name');
 var find = require('array-find');
+var isSpreadElement = function (node) {
+    return node.type === 'SpreadElement';
+};
 
 
 function Instrumentor (options) {
@@ -58,6 +61,11 @@ Instrumentor.prototype.createVisitor = function (ast) {
             } else if (currentNode.type === syntax.CallExpression) {
                 var matcher = find(that.matchers, function (matcher) { return matcher.test(currentNode); });
                 if (matcher) {
+                    // skip modifying argument if SpreadElement appears immediately beneath assert
+                    if (currentNode.arguments.some(isSpreadElement)) {
+                        skipping = true;
+                        return controller.skip();
+                    }
                     // entering target assertion
                     assertionVisitor = new AssertionVisitor(matcher, Object.assign({
                         storage: storage,

--- a/test/fixtures/SpreadElement/expected.js
+++ b/test/fixtures/SpreadElement/expected.js
@@ -47,3 +47,8 @@ assert(_rec3._expr(_rec3._capt(f(_rec3._capt(head, 'arguments/0/arguments/0'), .
     filepath: 'path/to/some_test.js',
     line: 7
 }));
+assert(...iter());
+assert(...[
+    foo,
+    bar
+]);

--- a/test/fixtures/SpreadElement/fixture.js
+++ b/test/fixtures/SpreadElement/fixture.js
@@ -5,3 +5,7 @@ assert(hello(...names));
 assert([head, ...tail].length);
 
 assert(f(head, ...iter(), ...[foo, bar]));
+
+assert(...iter());
+
+assert(...[foo, bar]);


### PR DESCRIPTION
Skip modifying argument if SpreadElement appears immediately beneath assert.

repro case:
```js
const args = [true === false, 'message'];
assert(...args);
```

`assert(...args)` looks like one argument syntactically, however there are two arguments actually.

`espower` works at the syntax level so it cannot handle SpreadElement that appears immediately beneath assert.

refs https://github.com/power-assert-js/babel-plugin-espower/pull/29