### PR TITLE
refactor: Extract node creator classes and functions out

### DIFF
--- a/lib/argument-modification.js
+++ b/lib/argument-modification.js
@@ -1,9 +1,6 @@
 'use strict';
 
-const estraverse = require('estraverse');
-const syntax = estraverse.Syntax;
-const espurify = require('espurify');
-const recorderClassAst = require('./power-assert-recorder.json');
+const { createNewRecorder, NodeCreator } = require('./create-node');
 
 class ArgumentModification {
   constructor ({ options, assertionPath, canonicalCode, location, withinGenerator, withinAsync }) {
@@ -78,136 +75,6 @@ class ArgumentModification {
   }
 }
 
-const createNewRecorder = ({ controller, transformation, storage, scopeStack, globalScope, visitorKeys }) => {
-  const currentBlock = findBlockedScope(scopeStack).block;
-  const scopeBlockEspath = findEspathOfAncestorNode(currentBlock, controller);
-  const recorderIdent = getOrCreateNode({
-    keyName: 'PowerAssertRecorder',
-    generateNode: () => espurify(recorderClassAst),
-    controller,
-    transformation,
-    storage,
-    scopeStack,
-    globalScope,
-    visitorKeys
-  });
-  const recorderVariableName = transformation.generateUniqueName('rec');
-  const currentNode = controller.current();
-  const types = new NodeCreator(currentNode);
-  const ident = types.identifier(recorderVariableName);
-  const init = types.newExpression(recorderIdent, []);
-  const decl = types.variableDeclaration('var', [
-    types.variableDeclarator(ident, init)
-  ]);
-  transformation.register(scopeBlockEspath, (matchNode) => {
-    let body;
-    if (/Function/.test(matchNode.type)) {
-      const blockStatement = matchNode.body;
-      body = blockStatement.body;
-    } else {
-      body = matchNode.body;
-    }
-    insertAfterUseStrictDirective(decl, body);
-  });
-  return ident;
-};
-
-const getOrCreateNode = ({ keyName, generateNode, controller, transformation, storage, globalScope, visitorKeys }) => {
-  return storage[keyName] || createNode({ keyName, generateNode, controller, transformation, storage, globalScope, visitorKeys });
-};
-
-const createNode = ({ keyName, generateNode, controller, transformation, storage, globalScope, visitorKeys }) => {
-  const globalScopeBlockEspath = findEspathOfAncestorNode(globalScope.block, controller);
-  const idName = transformation.generateUniqueName(keyName);
-  const generatedNode = generateNode();
-  const init = updateLocRecursively(generatedNode, {
-    loc: globalScope.block.loc,
-    range: globalScope.block.range,
-    visitorKeys
-  });
-  const types = new NodeCreator(globalScope.block);
-  const ident = types.identifier(idName);
-  const decl = types.variableDeclaration('var', [
-    types.variableDeclarator(ident, init)
-  ]);
-  transformation.register(globalScopeBlockEspath, (matchNode) => {
-    insertAfterUseStrictDirective(decl, matchNode.body);
-  });
-  storage[keyName] = ident;
-  return ident;
-};
-
-class NodeCreator {
-  constructor ({ loc, range }) {
-    this.createNode = newNodeWithLocation({ loc, range });
-  }
-  identifier (name) {
-    return this.createNode({
-      type: syntax.Identifier,
-      name
-    });
-  }
-  literal (value) {
-    return this.createNode({
-      type: syntax.Literal,
-      value
-    });
-  }
-  callExpression (callee, args) {
-    return this.createNode({
-      type: syntax.CallExpression,
-      callee,
-      arguments: args
-    });
-  }
-  newExpression (callee, args) {
-    return this.createNode({
-      type: syntax.NewExpression,
-      callee,
-      arguments: args
-    });
-  }
-  memberExpression (object, property, computed = false) {
-    return this.createNode({
-      type: syntax.MemberExpression,
-      object,
-      property,
-      computed
-    });
-  }
-  objectExpression (properties) {
-    return this.createNode({
-      type: syntax.ObjectExpression,
-      properties
-    });
-  }
-  property (key, value, computed = false, shorthand = false) {
-    return this.createNode({
-      type: syntax.Property,
-      key,
-      value,
-      method: false,
-      shorthand,
-      computed,
-      kind: 'init'
-    });
-  }
-  variableDeclaration (kind, declarations) {
-    return this.createNode({
-      type: syntax.VariableDeclaration,
-      declarations,
-      kind
-    });
-  }
-  variableDeclarator (id, init) {
-    return this.createNode({
-      type: syntax.VariableDeclarator,
-      id,
-      init
-    });
-  }
-}
-
 class NoModification {
   enter (controller) {
     this.currentArgumentPath = [].concat(controller.path());
@@ -223,99 +90,11 @@ class NoModification {
   }
 }
 
-const updateLocRecursively = (node, { loc, range, visitorKeys }) => {
-  const n = newNodeWithLocation({ loc, range });
-  const visitor = {
-    leave: function (currentNode, parentNode) {
-      return n(currentNode);
-    }
-  };
-  if (visitorKeys) {
-    visitor.keys = visitorKeys;
-  }
-  estraverse.replace(node, visitor);
-  return node;
-};
-
 const isPathIdentical = (path1, path2) => {
   if (!path1 || !path2) {
     return false;
   }
   return path1.join('/') === path2.join('/');
-};
-
-const newNodeWithLocation = ({ loc, range }) => {
-  return (newNode) => {
-    if (typeof loc !== 'undefined') {
-      const newLoc = {
-        start: {
-          line: loc.start.line,
-          column: loc.start.column
-        },
-        end: {
-          line: loc.end.line,
-          column: loc.end.column
-        }
-      };
-      if (typeof loc.source !== 'undefined') {
-        newLoc.source = loc.source;
-      }
-      newNode.loc = newLoc;
-    }
-    if (Array.isArray(range)) {
-      newNode.range = [range[0], range[1]];
-    }
-    return newNode;
-  };
-};
-
-const findBlockedScope = (scopeStack) => {
-  const lastIndex = scopeStack.length - 1;
-  const scope = scopeStack[lastIndex];
-  if (!scope.block || isArrowFunctionWithConciseBody(scope.block)) {
-    return findBlockedScope(scopeStack.slice(0, lastIndex));
-  }
-  return scope;
-};
-
-const isArrowFunctionWithConciseBody = (node) => {
-  return node.type === 'ArrowFunctionExpression' && node.body.type !== 'BlockStatement';
-};
-
-const findEspathOfAncestorNode = (targetNode, controller) => {
-  // iterate child to root
-  let child, parent;
-  const path = controller.path();
-  const parents = controller.parents();
-  const popUntilParent = (key) => {
-    if (parent[key] !== undefined) {
-      return;
-    }
-    popUntilParent(path.pop());
-  };
-  for (let i = parents.length - 1; i >= 0; i--) {
-    parent = parents[i];
-    if (child) {
-      popUntilParent(path.pop());
-    }
-    if (parent === targetNode) {
-      return path.join('/');
-    }
-    child = parent;
-  }
-  return null;
-};
-
-const insertAfterUseStrictDirective = (decl, body) => {
-  const firstBody = body[0];
-  if (firstBody.type === syntax.ExpressionStatement) {
-    const expression = firstBody.expression;
-    if (expression.type === syntax.Literal && expression.value === 'use strict') {
-      body.splice(1, 0, decl);
-      return;
-    }
-  }
-  body.unshift(decl);
 };
 
 module.exports = {

--- a/lib/argument-modification.js
+++ b/lib/argument-modification.js
@@ -41,30 +41,17 @@ class ArgumentModification {
     this.argumentModified = true;
     const currentNode = controller.current();
     const path = controller.path();
-    const n = newNodeWithLocationCopyOf(currentNode);
     const relativeEsPath = path.slice(this.assertionPath.length);
-    return n({
-      type: syntax.CallExpression,
-      callee: n({
-        type: syntax.MemberExpression,
-        computed: false,
-        object: this.valueRecorder,
-        property: n({
-          type: syntax.Identifier,
-          name: '_capt'
-        })
-      }),
-      arguments: [
-        currentNode,
-        n({
-          type: syntax.Literal,
-          value: relativeEsPath.join('/')
-        })
-      ]
-    });
+    const types = new NodeCreator(currentNode);
+    const callee = types.memberExpression(this.valueRecorder, types.identifier('_capt'));
+    return types.callExpression(callee, [
+      currentNode,
+      types.literal(relativeEsPath.join('/'))
+    ]);
   }
 
   captureArgument (node) {
+    const types = new NodeCreator(node);
     const n = newNodeWithLocationCopyOf(node);
     const props = [];
     addLiteralTo(props, n, 'content', this.canonicalCode);
@@ -76,22 +63,11 @@ class ArgumentModification {
     if (this.withinGenerator) {
       addLiteralTo(props, n, 'generator', true);
     }
-    return n({
-      type: syntax.CallExpression,
-      callee: n({
-        type: syntax.MemberExpression,
-        computed: false,
-        object: this.valueRecorder,
-        property: n({
-          type: syntax.Identifier,
-          name: '_expr'
-        })
-      }),
-      arguments: [node].concat(n({
-        type: syntax.ObjectExpression,
-        properties: props
-      }))
-    });
+    const callee = types.memberExpression(this.valueRecorder, types.identifier('_expr'));
+    return types.callExpression(callee, [
+      node,
+      types.objectExpression(props)
+    ]);
   }
 
   createNewRecorder (controller) {
@@ -99,15 +75,13 @@ class ArgumentModification {
     const scopeBlockEspath = findEspathOfAncestorNode(currentBlock, controller);
     const recorderConstructorName = this.getRecorderConstructorName(controller);
     const recorderVariableName = this.options.transformation.generateUniqueName('rec');
-
     const currentNode = controller.current();
-    const createNode = newNodeWithLocationCopyOf(currentNode);
-    const ident = createNode({
-      type: syntax.Identifier,
-      name: recorderVariableName
-    });
-    const init = this.createNewExpression(createNode, recorderConstructorName);
-    const decl = this.createVariableDeclaration(createNode, ident, init);
+    const types = new NodeCreator(currentNode);
+    const ident = types.identifier(recorderVariableName);
+    const init = types.newExpression(types.identifier(recorderConstructorName), []);
+    const decl = types.variableDeclaration('var', [
+      types.variableDeclarator(ident, init)
+    ]);
     this.options.transformation.register(scopeBlockEspath, (matchNode) => {
       let body;
       if (/Function/.test(matchNode.type)) {
@@ -134,41 +108,75 @@ class ArgumentModification {
     const globalScopeBlockEspath = findEspathOfAncestorNode(globalScope.block, controller);
     const createNode = newNodeWithLocationCopyOf(globalScope.block);
     const ctorName = this.options.transformation.generateUniqueName('PowerAssertRecorder');
-    const ident = createNode({
-      type: syntax.Identifier,
-      name: ctorName
-    });
+    const types = new NodeCreator(globalScope.block);
     const classDef = updateLocRecursively(espurify(recorderClassAst), createNode, this.options.visitorKeys);
-    const decl = this.createVariableDeclaration(createNode, ident, classDef);
+    const decl = types.variableDeclaration('var', [
+      types.variableDeclarator(types.identifier(ctorName), classDef)
+    ]);
     this.options.transformation.register(globalScopeBlockEspath, (matchNode) => {
       insertAfterUseStrictDirective(decl, matchNode.body);
     });
     this.options.storage.powerAssertRecorderConstructorName = ctorName;
     return ctorName;
   }
+}
 
-  createVariableDeclaration (createNode, ident, init) {
-    return createNode({
-      type: syntax.VariableDeclaration,
-      declarations: [
-        createNode({
-          type: syntax.VariableDeclarator,
-          id: ident,
-          init: init
-        })
-      ],
-      kind: 'var'
+class NodeCreator {
+  constructor (locationNode) {
+    this.createNode = newNodeWithLocationCopyOf(locationNode);
+  }
+  identifier (name) {
+    return this.createNode({
+      type: syntax.Identifier,
+      name
     });
   }
-
-  createNewExpression (createNode, constructorName) {
-    return createNode({
+  literal (value) {
+    return this.createNode({
+      type: syntax.Literal,
+      value
+    });
+  }
+  callExpression (callee, args) {
+    return this.createNode({
+      type: syntax.CallExpression,
+      callee,
+      arguments: args
+    });
+  }
+  newExpression (callee, args) {
+    return this.createNode({
       type: syntax.NewExpression,
-      callee: createNode({
-        type: syntax.Identifier,
-        name: constructorName
-      }),
-      arguments: []
+      callee,
+      arguments: args
+    });
+  }
+  memberExpression (object, property, computed = false) {
+    return this.createNode({
+      type: syntax.MemberExpression,
+      object,
+      property,
+      computed
+    });
+  }
+  objectExpression (properties) {
+    return this.createNode({
+      type: syntax.ObjectExpression,
+      properties
+    });
+  }
+  variableDeclaration (kind, declarations) {
+    return this.createNode({
+      type: syntax.VariableDeclaration,
+      declarations,
+      kind
+    });
+  }
+  variableDeclarator (id, init) {
+    return this.createNode({
+      type: syntax.VariableDeclarator,
+      id,
+      init
     });
   }
 }

--- a/lib/argument-modification.js
+++ b/lib/argument-modification.js
@@ -52,16 +52,21 @@ class ArgumentModification {
 
   captureArgument (node) {
     const types = new NodeCreator(node);
-    const n = newNodeWithLocationCopyOf(node);
     const props = [];
-    addLiteralTo(props, n, 'content', this.canonicalCode);
-    addLiteralTo(props, n, 'filepath', this.location.source);
-    addLiteralTo(props, n, 'line', this.location.line);
+    if (this.canonicalCode) {
+      props.push(types.property(types.identifier('content'), types.literal(this.canonicalCode)));
+    }
+    if (this.location && this.location.source) {
+      props.push(types.property(types.identifier('filepath'), types.literal(this.location.source)));
+    }
+    if (this.location && this.location.line) {
+      props.push(types.property(types.identifier('line'), types.literal(this.location.line)));
+    }
     if (this.withinAsync) {
-      addLiteralTo(props, n, 'async', true);
+      props.push(types.property(types.identifier('async'), types.literal(true)));
     }
     if (this.withinGenerator) {
-      addLiteralTo(props, n, 'generator', true);
+      props.push(types.property(types.identifier('generator'), types.literal(true)));
     }
     const callee = types.memberExpression(this.valueRecorder, types.identifier('_expr'));
     return types.callExpression(callee, [
@@ -165,6 +170,17 @@ class NodeCreator {
       properties
     });
   }
+  property (key, value, computed = false, shorthand = false) {
+    return this.createNode({
+      type: syntax.Property,
+      key,
+      value,
+      method: false,
+      shorthand,
+      computed,
+      kind: 'init'
+    });
+  }
   variableDeclaration (kind, declarations) {
     return this.createNode({
       type: syntax.VariableDeclaration,
@@ -195,30 +211,6 @@ class NoModification {
     return isPathIdentical(this.currentArgumentPath, controller.path());
   }
 }
-
-const addLiteralTo = (props, createNode, name, value) => {
-  if (typeof value !== 'undefined') {
-    addToProps(props, createNode, name, createNode({
-      type: syntax.Literal,
-      value: value
-    }));
-  }
-};
-
-const addToProps = (props, createNode, name, value) => {
-  props.push(createNode({
-    type: syntax.Property,
-    key: createNode({
-      type: syntax.Identifier,
-      name: name
-    }),
-    value: value,
-    method: false,
-    shorthand: false,
-    computed: false,
-    kind: 'init'
-  }));
-};
 
 const updateLocRecursively = (node, n, visitorKeys) => {
   const visitor = {

--- a/lib/argument-modification.js
+++ b/lib/argument-modification.js
@@ -18,7 +18,9 @@ class ArgumentModification {
 
   enter (controller) {
     // create recorder per argument
-    this.valueRecorder = this.createNewRecorder(controller);
+    this.valueRecorder = createNewRecorder(Object.assign({
+      controller
+    }, this.options));
     // entering target argument
     this.currentArgumentPath = [].concat(controller.path());
   }
@@ -74,60 +76,66 @@ class ArgumentModification {
       types.objectExpression(props)
     ]);
   }
-
-  createNewRecorder (controller) {
-    const currentBlock = findBlockedScope(this.options.scopeStack).block;
-    const scopeBlockEspath = findEspathOfAncestorNode(currentBlock, controller);
-    const recorderConstructorName = this.getRecorderConstructorName(controller);
-    const recorderVariableName = this.options.transformation.generateUniqueName('rec');
-    const currentNode = controller.current();
-    const types = new NodeCreator(currentNode);
-    const ident = types.identifier(recorderVariableName);
-    const init = types.newExpression(types.identifier(recorderConstructorName), []);
-    const decl = types.variableDeclaration('var', [
-      types.variableDeclarator(ident, init)
-    ]);
-    this.options.transformation.register(scopeBlockEspath, (matchNode) => {
-      let body;
-      if (/Function/.test(matchNode.type)) {
-        const blockStatement = matchNode.body;
-        body = blockStatement.body;
-      } else {
-        body = matchNode.body;
-      }
-      insertAfterUseStrictDirective(decl, body);
-    });
-    return ident;
-  }
-
-  getRecorderConstructorName (controller) {
-    let ctorName = this.options.storage.powerAssertRecorderConstructorName;
-    if (!ctorName) {
-      ctorName = this.createRecorderClass(controller);
-    }
-    return ctorName;
-  }
-
-  createRecorderClass (controller) {
-    const globalScope = this.options.globalScope;
-    const globalScopeBlockEspath = findEspathOfAncestorNode(globalScope.block, controller);
-    const ctorName = this.options.transformation.generateUniqueName('PowerAssertRecorder');
-    const classDef = updateLocRecursively(espurify(recorderClassAst), {
-      loc: globalScope.block.loc,
-      range: globalScope.block.range,
-      visitorKeys: this.options.visitorKeys
-    });
-    const types = new NodeCreator(globalScope.block);
-    const decl = types.variableDeclaration('var', [
-      types.variableDeclarator(types.identifier(ctorName), classDef)
-    ]);
-    this.options.transformation.register(globalScopeBlockEspath, (matchNode) => {
-      insertAfterUseStrictDirective(decl, matchNode.body);
-    });
-    this.options.storage.powerAssertRecorderConstructorName = ctorName;
-    return ctorName;
-  }
 }
+
+const createNewRecorder = ({ controller, transformation, storage, scopeStack, globalScope, visitorKeys }) => {
+  const currentBlock = findBlockedScope(scopeStack).block;
+  const scopeBlockEspath = findEspathOfAncestorNode(currentBlock, controller);
+  const recorderIdent = getOrCreateNode({
+    keyName: 'PowerAssertRecorder',
+    generateNode: () => espurify(recorderClassAst),
+    controller,
+    transformation,
+    storage,
+    scopeStack,
+    globalScope,
+    visitorKeys
+  });
+  const recorderVariableName = transformation.generateUniqueName('rec');
+  const currentNode = controller.current();
+  const types = new NodeCreator(currentNode);
+  const ident = types.identifier(recorderVariableName);
+  const init = types.newExpression(recorderIdent, []);
+  const decl = types.variableDeclaration('var', [
+    types.variableDeclarator(ident, init)
+  ]);
+  transformation.register(scopeBlockEspath, (matchNode) => {
+    let body;
+    if (/Function/.test(matchNode.type)) {
+      const blockStatement = matchNode.body;
+      body = blockStatement.body;
+    } else {
+      body = matchNode.body;
+    }
+    insertAfterUseStrictDirective(decl, body);
+  });
+  return ident;
+};
+
+const getOrCreateNode = ({ keyName, generateNode, controller, transformation, storage, globalScope, visitorKeys }) => {
+  return storage[keyName] || createNode({ keyName, generateNode, controller, transformation, storage, globalScope, visitorKeys });
+};
+
+const createNode = ({ keyName, generateNode, controller, transformation, storage, globalScope, visitorKeys }) => {
+  const globalScopeBlockEspath = findEspathOfAncestorNode(globalScope.block, controller);
+  const idName = transformation.generateUniqueName(keyName);
+  const generatedNode = generateNode();
+  const init = updateLocRecursively(generatedNode, {
+    loc: globalScope.block.loc,
+    range: globalScope.block.range,
+    visitorKeys
+  });
+  const types = new NodeCreator(globalScope.block);
+  const ident = types.identifier(idName);
+  const decl = types.variableDeclaration('var', [
+    types.variableDeclarator(ident, init)
+  ]);
+  transformation.register(globalScopeBlockEspath, (matchNode) => {
+    insertAfterUseStrictDirective(decl, matchNode.body);
+  });
+  storage[keyName] = ident;
+  return ident;
+};
 
 class NodeCreator {
   constructor ({ loc, range }) {

--- a/lib/argument-modification.js
+++ b/lib/argument-modification.js
@@ -111,10 +111,13 @@ class ArgumentModification {
   createRecorderClass (controller) {
     const globalScope = this.options.globalScope;
     const globalScopeBlockEspath = findEspathOfAncestorNode(globalScope.block, controller);
-    const createNode = newNodeWithLocationCopyOf(globalScope.block);
     const ctorName = this.options.transformation.generateUniqueName('PowerAssertRecorder');
+    const classDef = updateLocRecursively(espurify(recorderClassAst), {
+      loc: globalScope.block.loc,
+      range: globalScope.block.range,
+      visitorKeys: this.options.visitorKeys
+    });
     const types = new NodeCreator(globalScope.block);
-    const classDef = updateLocRecursively(espurify(recorderClassAst), createNode, this.options.visitorKeys);
     const decl = types.variableDeclaration('var', [
       types.variableDeclarator(types.identifier(ctorName), classDef)
     ]);
@@ -127,8 +130,8 @@ class ArgumentModification {
 }
 
 class NodeCreator {
-  constructor (locationNode) {
-    this.createNode = newNodeWithLocationCopyOf(locationNode);
+  constructor ({ loc, range }) {
+    this.createNode = newNodeWithLocation({ loc, range });
   }
   identifier (name) {
     return this.createNode({
@@ -212,7 +215,8 @@ class NoModification {
   }
 }
 
-const updateLocRecursively = (node, n, visitorKeys) => {
+const updateLocRecursively = (node, { loc, range, visitorKeys }) => {
+  const n = newNodeWithLocation({ loc, range });
   const visitor = {
     leave: function (currentNode, parentNode) {
       return n(currentNode);
@@ -232,26 +236,26 @@ const isPathIdentical = (path1, path2) => {
   return path1.join('/') === path2.join('/');
 };
 
-const newNodeWithLocationCopyOf = (original) => {
+const newNodeWithLocation = ({ loc, range }) => {
   return (newNode) => {
-    if (typeof original.loc !== 'undefined') {
+    if (typeof loc !== 'undefined') {
       const newLoc = {
         start: {
-          line: original.loc.start.line,
-          column: original.loc.start.column
+          line: loc.start.line,
+          column: loc.start.column
         },
         end: {
-          line: original.loc.end.line,
-          column: original.loc.end.column
+          line: loc.end.line,
+          column: loc.end.column
         }
       };
-      if (typeof original.loc.source !== 'undefined') {
-        newLoc.source = original.loc.source;
+      if (typeof loc.source !== 'undefined') {
+        newLoc.source = loc.source;
       }
       newNode.loc = newLoc;
     }
-    if (Array.isArray(original.range)) {
-      newNode.range = [original.range[0], original.range[1]];
+    if (Array.isArray(range)) {
+      newNode.range = [range[0], range[1]];
     }
     return newNode;
   };

--- a/lib/assertion-visitor.js
+++ b/lib/assertion-visitor.js
@@ -152,19 +152,6 @@ const isPathIdentical = (path1, path2) => {
   return path1.join('/') === path2.join('/');
 };
 
-const findBlockedScope = (scopeStack) => {
-  const lastIndex = scopeStack.length - 1;
-  const scope = scopeStack[lastIndex];
-  if (!scope.block || isArrowFunctionWithConciseBody(scope.block)) {
-    return findBlockedScope(scopeStack.slice(0, lastIndex));
-  }
-  return scope;
-};
-
-const isArrowFunctionWithConciseBody = (node) => {
-  return node.type === 'ArrowFunctionExpression' && node.body.type !== 'BlockStatement';
-};
-
 const isFunction = (node) => {
   switch (node.type) {
     case syntax.FunctionDeclaration:

--- a/lib/create-node-with-loc.js
+++ b/lib/create-node-with-loc.js
@@ -1,0 +1,119 @@
+'use strict';
+
+const estraverse = require('estraverse');
+const syntax = estraverse.Syntax;
+
+class NodeCreator {
+  constructor ({ loc, range }) {
+    this.createNode = newNodeWithLocation({ loc, range });
+  }
+  identifier (name) {
+    return this.createNode({
+      type: syntax.Identifier,
+      name
+    });
+  }
+  literal (value) {
+    return this.createNode({
+      type: syntax.Literal,
+      value
+    });
+  }
+  callExpression (callee, args) {
+    return this.createNode({
+      type: syntax.CallExpression,
+      callee,
+      arguments: args
+    });
+  }
+  newExpression (callee, args) {
+    return this.createNode({
+      type: syntax.NewExpression,
+      callee,
+      arguments: args
+    });
+  }
+  memberExpression (object, property, computed = false) {
+    return this.createNode({
+      type: syntax.MemberExpression,
+      object,
+      property,
+      computed
+    });
+  }
+  objectExpression (properties) {
+    return this.createNode({
+      type: syntax.ObjectExpression,
+      properties
+    });
+  }
+  property (key, value, computed = false, shorthand = false) {
+    return this.createNode({
+      type: syntax.Property,
+      key,
+      value,
+      method: false,
+      shorthand,
+      computed,
+      kind: 'init'
+    });
+  }
+  variableDeclaration (kind, declarations) {
+    return this.createNode({
+      type: syntax.VariableDeclaration,
+      declarations,
+      kind
+    });
+  }
+  variableDeclarator (id, init) {
+    return this.createNode({
+      type: syntax.VariableDeclarator,
+      id,
+      init
+    });
+  }
+}
+
+const updateLocRecursively = (node, { loc, range, visitorKeys }) => {
+  const n = newNodeWithLocation({ loc, range });
+  const visitor = {
+    leave: function (currentNode, parentNode) {
+      return n(currentNode);
+    }
+  };
+  if (visitorKeys) {
+    visitor.keys = visitorKeys;
+  }
+  estraverse.replace(node, visitor);
+  return node;
+};
+
+const newNodeWithLocation = ({ loc, range }) => {
+  return (newNode) => {
+    if (typeof loc !== 'undefined') {
+      const newLoc = {
+        start: {
+          line: loc.start.line,
+          column: loc.start.column
+        },
+        end: {
+          line: loc.end.line,
+          column: loc.end.column
+        }
+      };
+      if (typeof loc.source !== 'undefined') {
+        newLoc.source = loc.source;
+      }
+      newNode.loc = newLoc;
+    }
+    if (Array.isArray(range)) {
+      newNode.range = [range[0], range[1]];
+    }
+    return newNode;
+  };
+};
+
+module.exports = {
+  updateLocRecursively,
+  NodeCreator
+};

--- a/lib/create-node.js
+++ b/lib/create-node.js
@@ -1,0 +1,120 @@
+'use strict';
+
+const estraverse = require('estraverse');
+const syntax = estraverse.Syntax;
+const espurify = require('espurify');
+const recorderClassAst = require('./power-assert-recorder.json');
+const { updateLocRecursively, NodeCreator } = require('./create-node-with-loc');
+
+const createNewRecorder = ({ controller, transformation, storage, scopeStack, globalScope, visitorKeys }) => {
+  const currentBlock = findBlockedScope(scopeStack).block;
+  const scopeBlockEspath = findEspathOfAncestorNode(currentBlock, controller);
+  const recorderIdent = getOrCreateNode({
+    keyName: 'PowerAssertRecorder',
+    generateNode: () => espurify(recorderClassAst),
+    controller,
+    transformation,
+    storage,
+    scopeStack,
+    globalScope,
+    visitorKeys
+  });
+  const recorderVariableName = transformation.generateUniqueName('rec');
+  const currentNode = controller.current();
+  const types = new NodeCreator(currentNode);
+  const ident = types.identifier(recorderVariableName);
+  const init = types.newExpression(recorderIdent, []);
+  const decl = types.variableDeclaration('var', [
+    types.variableDeclarator(ident, init)
+  ]);
+  transformation.register(scopeBlockEspath, (matchNode) => {
+    let body;
+    if (/Function/.test(matchNode.type)) {
+      const blockStatement = matchNode.body;
+      body = blockStatement.body;
+    } else {
+      body = matchNode.body;
+    }
+    insertAfterUseStrictDirective(decl, body);
+  });
+  return ident;
+};
+
+const getOrCreateNode = ({ keyName, generateNode, controller, transformation, storage, globalScope, visitorKeys }) => {
+  return storage[keyName] || createNode({ keyName, generateNode, controller, transformation, storage, globalScope, visitorKeys });
+};
+
+const createNode = ({ keyName, generateNode, controller, transformation, storage, globalScope, visitorKeys }) => {
+  const globalScopeBlockEspath = findEspathOfAncestorNode(globalScope.block, controller);
+  const idName = transformation.generateUniqueName(keyName);
+  const generatedNode = generateNode();
+  const init = updateLocRecursively(generatedNode, {
+    loc: globalScope.block.loc,
+    range: globalScope.block.range,
+    visitorKeys
+  });
+  const types = new NodeCreator(globalScope.block);
+  const ident = types.identifier(idName);
+  const decl = types.variableDeclaration('var', [
+    types.variableDeclarator(ident, init)
+  ]);
+  transformation.register(globalScopeBlockEspath, (matchNode) => {
+    insertAfterUseStrictDirective(decl, matchNode.body);
+  });
+  storage[keyName] = ident;
+  return ident;
+};
+
+const findBlockedScope = (scopeStack) => {
+  const lastIndex = scopeStack.length - 1;
+  const scope = scopeStack[lastIndex];
+  if (!scope.block || isArrowFunctionWithConciseBody(scope.block)) {
+    return findBlockedScope(scopeStack.slice(0, lastIndex));
+  }
+  return scope;
+};
+
+const isArrowFunctionWithConciseBody = (node) => {
+  return node.type === 'ArrowFunctionExpression' && node.body.type !== 'BlockStatement';
+};
+
+const findEspathOfAncestorNode = (targetNode, controller) => {
+  // iterate child to root
+  let child, parent;
+  const path = controller.path();
+  const parents = controller.parents();
+  const popUntilParent = (key) => {
+    if (parent[key] !== undefined) {
+      return;
+    }
+    popUntilParent(path.pop());
+  };
+  for (let i = parents.length - 1; i >= 0; i--) {
+    parent = parents[i];
+    if (child) {
+      popUntilParent(path.pop());
+    }
+    if (parent === targetNode) {
+      return path.join('/');
+    }
+    child = parent;
+  }
+  return null;
+};
+
+const insertAfterUseStrictDirective = (decl, body) => {
+  const firstBody = body[0];
+  if (firstBody.type === syntax.ExpressionStatement) {
+    const expression = firstBody.expression;
+    if (expression.type === syntax.Literal && expression.value === 'use strict') {
+      body.splice(1, 0, decl);
+      return;
+    }
+  }
+  body.unshift(decl);
+};
+
+module.exports = {
+  createNewRecorder,
+  NodeCreator
+};


### PR DESCRIPTION
behavior preserving refactoring before big feature addition

- introduce babel-types like NodeCreator class
- extract createNewRecorder function out