### PR TITLE
feat: enhance assertion message even if it is a string literal

### DIFF
--- a/lib/assertion-visitor.js
+++ b/lib/assertion-visitor.js
@@ -10,7 +10,7 @@ const syntax = estraverse.Syntax;
 const EspowerLocationDetector = require('espower-location-detector');
 const toBeSkipped = require('./rules/to-be-skipped');
 const toBeCaptured = require('./rules/to-be-captured');
-const { getParentNode } = require('./controller-utils');
+const { getParentNode, getCurrentKey } = require('./controller-utils');
 const recorderClassAst = require('./templates/argument-recorder.json');
 const assertionMessageClassAst = require('./templates/assertion-message');
 const canonicalCodeOptions = {
@@ -99,7 +99,10 @@ class AssertionVisitor {
   }
 
   toBeSkipped (controller) {
-    return toBeSkipped(controller);
+    const currentNode = controller.current();
+    const parentNode = getParentNode(controller);
+    const currentKey = getCurrentKey(controller);
+    return toBeSkipped({ currentNode, parentNode, currentKey });
   }
 
   toBeCaptured (controller) {
@@ -136,12 +139,24 @@ class AssertionVisitor {
     const numActualArgs = currentNode.arguments.length;
     const onlyLastArgumentIsOmitted = (numDefinedParams - numActualArgs === 1);
 
+    const params = Object.assign({
+      controller,
+      metadataIdent: this.metadataIdent
+    }, this.options);
+
     if (onlyLastArgumentIsOmitted) {
       // appending AssertionMessage in place of omitted message argument (as index -1)
-      currentNode.arguments.push(createNewAssertionMessage(Object.assign({
-        controller,
-        metadataIdent: this.metadataIdent
-      }, this.options)));
+      currentNode.arguments.push(createNewAssertionMessage(params));
+    } else if (numDefinedParams === numActualArgs) {
+      const lastIndex = numActualArgs - 1;
+      const lastActualArg = currentNode.arguments[lastIndex];
+      if (toBeSkipped({ currentNode: lastActualArg, parentNode: currentNode, currentKey: lastIndex })) {
+        // last arg may be a string literal
+        currentNode.arguments[lastIndex] = createNewAssertionMessage(Object.assign({}, {
+          originalMessageNode: lastActualArg,
+          matchIndex: lastIndex
+        }, params));
+      }
     }
     return currentNode;
   }

--- a/lib/rules/to-be-skipped.js
+++ b/lib/rules/to-be-skipped.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { Syntax } = require('estraverse');
-const { getParentNode, getCurrentKey } = require('../controller-utils');
 const supportedNodeTypes = require('./supported-node-types');
 
 const isLeftHandSideOfAssignment = (parentNode, currentKey) => {
@@ -50,10 +49,7 @@ const isSupportedNodeType = (node) => {
   return supportedNodeTypes.indexOf(node.type) !== -1;
 };
 
-const toBeSkipped = (controller) => {
-  const currentNode = controller.current();
-  const parentNode = getParentNode(controller);
-  const currentKey = getCurrentKey(controller);
+const toBeSkipped = ({ currentNode, parentNode, currentKey }) => {
   return !isSupportedNodeType(currentNode) ||
         isLeftHandSideOfAssignment(parentNode, currentKey) ||
         isNonComputedObjectLiteralKey(parentNode, currentKey) ||

--- a/test/fixtures/BinaryExpression/expected.js
+++ b/test/fixtures/BinaryExpression/expected.js
@@ -361,6 +361,6 @@ assert(_ag3._rec(_ag3._tap(fuga, 'arguments/0/left') === _ag3._tap(piyo, 'argume
 assert(_ag4._rec(_ag4._tap(fuga, 'arguments/0/left') === _ag4._tap(piyo, 'arguments/0/right'), 'arguments/0'), new _AssertionMessage1(_am4, -1));
 assert(_ag5._rec(_ag5._tap(fuga, 'arguments/0/left') === _ag5._tap(piyo, 'arguments/0/right'), 'arguments/0'), new _AssertionMessage1(_am5, -1));
 assert(_ag6._rec(_ag6._tap(fuga, 'arguments/0/left') !== _ag6._tap(piyo, 'arguments/0/right'), 'arguments/0'), new _AssertionMessage1(_am6, -1));
-assert.ok(_ag7._rec(_ag7._tap(hoge, 'arguments/0/left') === _ag7._tap(fuga, 'arguments/0/right'), 'arguments/0'), 'comment');
+assert.ok(_ag7._rec(_ag7._tap(hoge, 'arguments/0/left') === _ag7._tap(fuga, 'arguments/0/right'), 'arguments/0'), new _AssertionMessage1(_am7, 1, 'comment'));
 assert(_ag8._rec(_ag8._tap(_ag8._tap(ary1, 'arguments/0/left/object').length, 'arguments/0/left') === _ag8._tap(_ag8._tap(ary2, 'arguments/0/right/object').length, 'arguments/0/right'), 'arguments/0'), new _AssertionMessage1(_am8, -1));
 assert(_ag9._rec(_ag9._tap(foo, 'arguments/0/left') instanceof _ag9._tap(Foo, 'arguments/0/right'), 'arguments/0'), new _AssertionMessage1(_am9, -1));

--- a/test/fixtures/Literal/expected.js
+++ b/test/fixtures/Literal/expected.js
@@ -358,7 +358,7 @@ assert(0);
 assert.equal(1, 0);
 assert(false, 'message');
 assert(false, new _AssertionMessage1(_am5, 1, _ag1._rec(messageStr, 'arguments/1')));
-assert.equal(_ag2._rec(foo, 'arguments/0'), 'bar', 'msg');
+assert.equal(_ag2._rec(foo, 'arguments/0'), 'bar', new _AssertionMessage1(_am6, 2, 'msg'));
 assert(_ag3._rec(/^not/.exec(_ag3._tap(str, 'arguments/0/arguments/0')), 'arguments/0'), new _AssertionMessage1(_am7, -1));
 assert(_ag4._rec(_ag4._tap(fuga, 'arguments/0/left') !== 'ふが', 'arguments/0'), new _AssertionMessage1(_am8, -1));
 assert(_ag5._rec('ほげ' !== 'ふが', 'arguments/0'), new _AssertionMessage1(_am9, -1));

--- a/test/fixtures/Mocha/expected.js
+++ b/test/fixtures/Mocha/expected.js
@@ -357,7 +357,7 @@ describe('Array', function () {
             var _am2 = _pwmeta1(1, 'assert.ok(this.ary.indexOf(two) === minusOne, \'THIS IS AN ASSERTION MESSAGE\')', 'path/to/some_test.js', 16);
             var _ag2 = new _ArgumentRecorder1(assert.ok, _am2, 0);
             var minusOne = -1, two = 2;
-            assert.ok(_ag2._rec(_ag2._tap(_ag2._tap(this.ary, 'arguments/0/left/callee/object').indexOf(_ag2._tap(two, 'arguments/0/left/arguments/0')), 'arguments/0/left') === _ag2._tap(minusOne, 'arguments/0/right'), 'arguments/0'), 'THIS IS AN ASSERTION MESSAGE');
+            assert.ok(_ag2._rec(_ag2._tap(_ag2._tap(this.ary, 'arguments/0/left/callee/object').indexOf(_ag2._tap(two, 'arguments/0/left/arguments/0')), 'arguments/0/left') === _ag2._tap(minusOne, 'arguments/0/right'), 'arguments/0'), new _AssertionMessage1(_am2, 1, 'THIS IS AN ASSERTION MESSAGE'));
         });
     });
     it('#length', function () {
@@ -372,6 +372,6 @@ describe('Array', function () {
         var _ag5 = new _ArgumentRecorder1(assert.equal, _am4, 0);
         var _ag6 = new _ArgumentRecorder1(assert.equal, _am4, 1);
         var four = 4;
-        assert.equal(_ag5._rec(_ag5._tap(this.ary, 'arguments/0/object').length, 'arguments/0'), _ag6._rec(four, 'arguments/1'), 'THIS IS AN ASSERTION MESSAGE');
+        assert.equal(_ag5._rec(_ag5._tap(this.ary, 'arguments/0/object').length, 'arguments/0'), _ag6._rec(four, 'arguments/1'), new _AssertionMessage1(_am4, 2, 'THIS IS AN ASSERTION MESSAGE'));
     });
 });

--- a/test/fixtures/WithoutRequireAssert/expected.js
+++ b/test/fixtures/WithoutRequireAssert/expected.js
@@ -355,6 +355,6 @@ describe('Array#indexOf()', function () {
         var _am2 = _pwmeta1(1, 'assert.ok(this.ary.indexOf(two) === minusOne, \'THIS IS AN ASSERTION MESSAGE\')', 'path/to/some_test.js', 13);
         var _ag2 = new _ArgumentRecorder1(assert.ok, _am2, 0);
         var minusOne = -1, two = 2;
-        assert.ok(_ag2._rec(_ag2._tap(_ag2._tap(this.ary, 'arguments/0/left/callee/object').indexOf(_ag2._tap(two, 'arguments/0/left/arguments/0')), 'arguments/0/left') === _ag2._tap(minusOne, 'arguments/0/right'), 'arguments/0'), 'THIS IS AN ASSERTION MESSAGE');
+        assert.ok(_ag2._rec(_ag2._tap(_ag2._tap(this.ary, 'arguments/0/left/callee/object').indexOf(_ag2._tap(two, 'arguments/0/left/arguments/0')), 'arguments/0/left') === _ag2._tap(minusOne, 'arguments/0/right'), 'arguments/0'), new _AssertionMessage1(_am2, 1, 'THIS IS AN ASSERTION MESSAGE'));
     });
 });

--- a/test/fixtures/WithoutUseStrict/expected.js
+++ b/test/fixtures/WithoutUseStrict/expected.js
@@ -355,6 +355,6 @@ describe('Array#indexOf()', function () {
         var _am2 = _pwmeta1(1, 'assert.ok(this.ary.indexOf(two) === minusOne, \'THIS IS AN ASSERTION MESSAGE\')', 'path/to/some_test.js', 13);
         var _ag2 = new _ArgumentRecorder1(assert.ok, _am2, 0);
         var minusOne = -1, two = 2;
-        assert.ok(_ag2._rec(_ag2._tap(_ag2._tap(this.ary, 'arguments/0/left/callee/object').indexOf(_ag2._tap(two, 'arguments/0/left/arguments/0')), 'arguments/0/left') === _ag2._tap(minusOne, 'arguments/0/right'), 'arguments/0'), 'THIS IS AN ASSERTION MESSAGE');
+        assert.ok(_ag2._rec(_ag2._tap(_ag2._tap(this.ary, 'arguments/0/left/callee/object').indexOf(_ag2._tap(two, 'arguments/0/left/arguments/0')), 'arguments/0/left') === _ag2._tap(minusOne, 'arguments/0/right'), 'arguments/0'), new _AssertionMessage1(_am2, 1, 'THIS IS AN ASSERTION MESSAGE'));
     });
 });

--- a/test/fixtures/WithoutUseStrictNorRequireAssert/expected.js
+++ b/test/fixtures/WithoutUseStrictNorRequireAssert/expected.js
@@ -354,6 +354,6 @@ describe('Array#indexOf()', function () {
         var _am2 = _pwmeta1(1, 'assert.ok(this.ary.indexOf(two) === minusOne, \'THIS IS AN ASSERTION MESSAGE\')', 'path/to/some_test.js', 11);
         var _ag2 = new _ArgumentRecorder1(assert.ok, _am2, 0);
         var minusOne = -1, two = 2;
-        assert.ok(_ag2._rec(_ag2._tap(_ag2._tap(this.ary, 'arguments/0/left/callee/object').indexOf(_ag2._tap(two, 'arguments/0/left/arguments/0')), 'arguments/0/left') === _ag2._tap(minusOne, 'arguments/0/right'), 'arguments/0'), 'THIS IS AN ASSERTION MESSAGE');
+        assert.ok(_ag2._rec(_ag2._tap(_ag2._tap(this.ary, 'arguments/0/left/callee/object').indexOf(_ag2._tap(two, 'arguments/0/left/arguments/0')), 'arguments/0/left') === _ag2._tap(minusOne, 'arguments/0/right'), 'arguments/0'), new _AssertionMessage1(_am2, 1, 'THIS IS AN ASSERTION MESSAGE'));
     });
 });


### PR DESCRIPTION
to generate fallback-mode assertion message even if power-assert runtime does not exist