### PR TITLE
perf: introduce tiny and fast call-matcher alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ VisitorKeys for AST traversal. See [estraverse.VisitorKeys](https://github.com/e
 |:--------------------|:--------------|
 | `function`          | N/A           |
 
-A function to parse pattern string specified by `options.patterns`. This property is optional.
+A function to parse pattern string specified by `options.patterns`. This property is optional and only required to parse a bit complicated custom pattern string like "browser.assert.element(selection, [message])".
 
 
 ### const options = espower.defaultOptions();

--- a/lib/create-pattern-matchers.js
+++ b/lib/create-pattern-matchers.js
@@ -12,6 +12,9 @@ const createPatternMatchers = (options) => {
     if (parsed) {
       matcher = new SigMatcher(parsed);
     } else {
+      if (typeof options.parse !== 'function') {
+        throw new Error(`[espower] options.parse is required to parse a bit complicated custom pattern string "${pattern}"`);
+      }
       const signatureAst = options.parse(pattern);
       const expression = signatureAst.body[0].expression;
       matcher = new CallMatcher(expression, options);

--- a/lib/create-pattern-matchers.js
+++ b/lib/create-pattern-matchers.js
@@ -1,13 +1,21 @@
 'use strict';
 
 const CallMatcher = require('call-matcher');
+const signature = require('call-signature');
+const SigMatcher = require('./sig-matcher');
 
 const createPatternMatchers = (options) => {
   return options.patterns.map((p, index) => {
     const pattern = typeof p === 'string' ? p : p.pattern;
-    const signatureAst = options.parse(pattern);
-    const expression = signatureAst.body[0].expression;
-    const matcher = new CallMatcher(expression, options);
+    const parsed = signature.parse(pattern);
+    let matcher;
+    if (parsed) {
+      matcher = new SigMatcher(parsed);
+    } else {
+      const signatureAst = options.parse(pattern);
+      const expression = signatureAst.body[0].expression;
+      matcher = new CallMatcher(expression, options);
+    }
     const args = matcher.argumentSignatures().map((sig, idx) => {
       if (typeof p === 'object' && p !== null && Array.isArray(p.args)) {
         return Object.assign({}, sig, p.args[idx]);

--- a/lib/sig-matcher.js
+++ b/lib/sig-matcher.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const isIdentifier = (node) => node && node.type === 'Identifier';
+const isCallExpression = (node) => node && node.type === 'CallExpression';
+const hasIdentName = (node, name) => isIdentifier(node) && node.name === name;
+const isCalleeOfParent = (currentNode, parentNode) => parentNode &&
+          currentNode &&
+          parentNode.type === 'CallExpression' &&
+          parentNode.callee === currentNode;
+
+class SigMatcher {
+  constructor ({ callee, args }) {
+    this.callee = callee;
+    this.args = args;
+    this.numMaxArgs = args.length;
+    this.numMinArgs = args.filter((a) => a.optional === false).length;
+  }
+  test (currentNode) {
+    if (this.isCalleeMatched(currentNode)) {
+      const numArgs = currentNode.arguments.length;
+      return this.numMinArgs <= numArgs && numArgs <= this.numMaxArgs;
+    }
+    return false;
+  }
+  matchArgument (currentNode, parentNode) {
+    if (isCalleeOfParent(currentNode, parentNode)) {
+      return null;
+    }
+    if (this.test(parentNode)) {
+      const indexOfCurrentArg = parentNode.arguments.indexOf(currentNode);
+      let numOptional = parentNode.arguments.length - this.numMinArgs;
+      const matchedSignatures = this.argumentSignatures().reduce((accum, argSig) => {
+        if (argSig.kind === 'mandatory') {
+          accum.push(argSig);
+        }
+        if (argSig.kind === 'optional' && numOptional > 0) {
+          numOptional -= 1;
+          accum.push(argSig);
+        }
+        return accum;
+      }, []);
+      return matchedSignatures[indexOfCurrentArg];
+    }
+    return null;
+  }
+  argumentSignatures () {
+    return this.args.map(toArgumentSignature);
+  }
+  isCalleeMatched (currentNode) {
+    if (!isCallExpression(currentNode)) {
+      return false;
+    }
+    const callee = currentNode.callee;
+    switch (this.callee.type) {
+      case 'Identifier':
+        return hasIdentName(callee, this.callee.name);
+      case 'MemberExpression':
+        const memObj = callee.object;
+        const memProp = callee.property;
+        return hasIdentName(memObj, this.callee.object) && hasIdentName(memProp, this.callee.member);
+      default:
+        return false;
+    }
+  }
+}
+const toArgumentSignature = (arg, idx) => {
+  return {
+    index: idx,
+    name: arg.name,
+    kind: arg.optional ? 'optional' : 'mandatory'
+  };
+};
+
+module.exports = SigMatcher;

--- a/lib/sig-matcher.js
+++ b/lib/sig-matcher.js
@@ -23,6 +23,7 @@ class SigMatcher {
     return false;
   }
   matchArgument (currentNode, parentNode) {
+    /* istanbul ignore next */
     if (isCalleeOfParent(currentNode, parentNode)) {
       return null;
     }
@@ -58,6 +59,7 @@ class SigMatcher {
         const memObj = callee.object;
         const memProp = callee.property;
         return hasIdentName(memObj, this.callee.object) && hasIdentName(memProp, this.callee.member);
+      /* istanbul ignore next */
       default:
         return false;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -322,6 +322,11 @@
         "estraverse": "^4.0.0"
       }
     },
+    "call-signature": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
+      "integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY="
+    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "dependencies": {
     "call-matcher": "^2.0.0",
+    "call-signature": "^0.0.2",
     "escodegen": "^1.7.0",
     "escope": "^3.3.0",
     "espower-location-detector": "^2.0.0",

--- a/test/espower_option_test.js
+++ b/test/espower_option_test.js
@@ -76,7 +76,7 @@ describe('instrumentation tests for options', function () {
       it(testName, function () {
         var tree = acorn.parse('assert(falsyStr);', { ecmaVersion: 6, locations: true, ranges: true });
         var saved = deepCopy(tree);
-        var result = espower(tree, Object.assign({ parse: acorn.parse }, options));
+        var result = espower(tree, options);
         callback(assert, saved, tree, result);
       });
     }
@@ -88,7 +88,7 @@ describe('instrumentation tests for options', function () {
     it('options.destructive is deprecate and always treated as destructive:true', function () {
       var tree = acorn.parse('assert(falsyStr);', { ecmaVersion: 6, locations: true, ranges: true });
       assert.throws(function () {
-        espower(tree, { parse: acorn.parse, destructive: false });
+        espower(tree, { destructive: false });
       }, Error);
     });
     destructiveOptionTest('destructive: true', { destructive: true }, function (assert, before, tree, after) {
@@ -140,6 +140,7 @@ describe('instrumentation tests for options', function () {
       suite: 'deep callee chain: browser.assert.element(selection, [message])',
       input: 'browser.assert.element(foo);',
       espowerOptions: {
+        parse: acorn.parse,
         patterns: [
           'browser.assert.element(selection, [message])'
         ]
@@ -158,7 +159,7 @@ describe('instrumentation tests for options', function () {
   describe('path option.', function () {
     function instrument (jsCode, options) {
       var jsAST = acorn.parse(jsCode, { ecmaVersion: 7, locations: true, plugins: { asyncawait: true } });
-      var espoweredAST = espower(jsAST, Object.assign({ parse: acorn.parse }, options));
+      var espoweredAST = espower(jsAST, options);
       var instrumentedCode = escodegen.generate(espoweredAST, { format: { compact: true } });
       return instrumentedCode;
     }
@@ -184,7 +185,7 @@ describe('option prerequisites', function () {
   function optionPrerequisitesTest (name, options, expected) {
     it(name, function () {
       try {
-        espower(this.tree, Object.assign({ parse: acorn.parse }, options));
+        espower(this.tree, options);
         assert.ok(false, 'Error should be thrown');
       } catch (e) {
         assert.strictEqual(e.message, expected);
@@ -207,7 +208,7 @@ describe('AST prerequisites. Error should be thrown if location is missing.', fu
   });
   it('error message when path option is not specified', function () {
     try {
-      espower(this.tree, { parse: acorn.parse });
+      espower(this.tree);
       assert.ok(false, 'Error should be thrown');
     } catch (e) {
       assert.strictEqual(e.name, 'Error');
@@ -218,7 +219,7 @@ describe('AST prerequisites. Error should be thrown if location is missing.', fu
   });
   it('error message when path option is specified', function () {
     try {
-      espower(this.tree, { parse: acorn.parse, path: '/path/to/baz_test.js' });
+      espower(this.tree, { path: '/path/to/baz_test.js' });
       assert.ok(false, 'Error should be thrown');
     } catch (e) {
       assert.strictEqual(e.name, 'Error');
@@ -234,7 +235,7 @@ describe('AST prerequisites. Error should be thrown if AST is already instrument
     var alreadyEspoweredCode = "assert(_ag1._rec(falsyStr, 'arguments/0'), new _AssertionMessage1(_am1, -1));";
     var ast = acorn.parse(alreadyEspoweredCode, { ecmaVersion: 6, locations: true });
     try {
-      espower(ast, { parse: acorn.parse, path: '/path/to/baz_test.js' });
+      espower(ast, { path: '/path/to/baz_test.js' });
       assert.ok(false, 'Error should be thrown');
     } catch (e) {
       assert.strictEqual(e.name, 'Error');
@@ -269,7 +270,7 @@ describe('location information', function () {
   it('preserve location of instrumented nodes.', function () {
     var jsCode = 'assert((three * (seven * ten)) === three);';
     var tree = acorn.parse(jsCode, { ecmaVersion: 6, locations: true, ranges: true });
-    var result = espower(tree, { parse: acorn.parse, path: '/path/to/baz_test.js' });
+    var result = espower(tree, { path: '/path/to/baz_test.js' });
     estraverse.traverse(result, function (node) {
       if (typeof node.type === 'undefined') return;
       assert.ok(typeof node.loc !== 'undefined', 'type: ' + node.type);
@@ -335,7 +336,6 @@ describe('incoming SourceMap support', function () {
 
       var intermediateFilepath = '/path/to/absolute/intermediate/transformed_test.js';
       var espoweredAST = espower(acorn.parse(compactCode, { ecmaVersion: 6, locations: true, sourceFile: intermediateFilepath }), {
-        parse: acorn.parse,
         patterns: [
           'assert.equal(actual, expected, [message])'
         ],

--- a/test/espower_option_test.js
+++ b/test/espower_option_test.js
@@ -176,6 +176,27 @@ describe('instrumentation tests for options', function () {
       assert(instrumentedCode.includes("var _am1=_pwmeta1(0,'assert(falsyStr)','path/to/baz_test.js',1);"));
     });
   });
+
+  describe('parse option', function () {
+    it('required to use pattern string like "browser.assert.element(selection, [message]);"', function () {
+      var ast = acorn.parse('browser.assert.element(foo);', { ecmaVersion: 6, locations: true });
+      try {
+        espower(ast, {
+          // parse: acorn.parse,  // if parse option is not specified
+          path: '/path/to/foo_test.js',
+          patterns: [
+            'browser.assert.element(selection, [message])'
+          ]
+        });
+        assert.ok(false, 'Error should be thrown');
+      } catch (e) {
+        assert.strictEqual(e.name, 'Error');
+        assert(e instanceof Error);
+        assert.strictEqual(e.message, '[espower] options.parse is required to parse a bit complicated custom pattern string "browser.assert.element(selection, [message])"');
+        assert(e.stack);
+      }
+    });
+  });
 });
 
 describe('option prerequisites', function () {

--- a/test/fixture_test.js
+++ b/test/fixture_test.js
@@ -16,7 +16,7 @@ function testWithParser (fixtureName, parse, manipulate) {
     var actualFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'actual.js');
 
     var jsAST = parse(fs.readFileSync(fixtureFilepath, 'utf8'));
-    var espoweredAST = manipulate(jsAST, { ecmaVersion: 2018, path: 'path/to/some_test.js', parse: parse });
+    var espoweredAST = manipulate(jsAST, { ecmaVersion: 2018, path: 'path/to/some_test.js' });
     var output = escodegen.generate(espoweredAST);
 
     var actual = output + '\n';

--- a/test/helper.js
+++ b/test/helper.js
@@ -6,7 +6,7 @@ const espower = require('..');
 const transpile = ({ input, espowerOptions = {}, parserOptions = {} }) => {
   const options = Object.assign({ ecmaVersion: 2018, locations: true, ranges: true, plugins: { asyncawait: true } }, parserOptions);
   const ast = acorn.parse(input, options);
-  const espoweredAST = espower(ast, Object.assign({ path: 'path/to/some_test.js', parse: acorn.parse }, espowerOptions));
+  const espoweredAST = espower(ast, Object.assign({ path: 'path/to/some_test.js' }, espowerOptions));
   const result = escodegen.generate(espoweredAST, { format: { compact: true } });
   const lines = result.split('\n');
   const lastLine = lines[lines.length - 1];

--- a/test/visitor_keys_test.js
+++ b/test/visitor_keys_test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var espower = require('..');
-var acorn = require('acorn');
 var assert = require('assert');
 
 /// / original code of jsx_test.json:
@@ -28,6 +27,6 @@ var ast = require('./jsx_test.json');
 it('custom visitorKeys', function () {
   var visitorKeys = require('./visitor-keys.json');
   assert.doesNotThrow(function () {
-    espower(ast, { visitorKeys: visitorKeys, parse: acorn.parse });
+    espower(ast, { visitorKeys: visitorKeys });
   });
 });


### PR DESCRIPTION
Introduce tiny and fast `call-matcher` alternative based on `call-signature` that works simple case like `func(arg)` or `method.call(arg)`.

In case of a bit complicated custom pattern string like `"browser.assert.element(selection, [message])"`, espower fallbacks to `call-matcher` if `call-signature` failed to parse. In such case, `options.parse` is required.


#### benchmark result
```
v2.1.2 x 13.26 ops/sec ±6.63% (38 runs sampled)
master x 12.81 ops/sec ±5.53% (36 runs sampled)
call-signature x 26.58 ops/sec ±5.43% (47 runs sampled)
Fastest is call-signature
```
