### PR TITLE
fix: dealing with node not to be captured that appears immediately beneath assert

### DIFF
--- a/lib/argument-modification.js
+++ b/lib/argument-modification.js
@@ -27,8 +27,11 @@ class ArgumentModification {
   }
 
   leave (controller) {
-    const shouldCapture = this.isArgumentModified() || toBeCaptured(controller);
-    const resultNode = shouldCapture ? this.captureArgument(controller) : controller.current();
+    const currentNode = controller.current();
+    const shouldCaptureValue = toBeCaptured(controller);
+    const pathToBeCaptured = shouldCaptureValue ? controller.path() : null;
+    const shouldCaptureArgument = this.isArgumentModified() || shouldCaptureValue;
+    const resultNode = shouldCaptureArgument ? this.captureArgument(currentNode, pathToBeCaptured) : currentNode;
     if (this.currentArgumentMatchResult.name === 'message' && this.currentArgumentMatchResult.kind === 'optional') {
       this.messageUpdated = true;
       // enclose it in AssertionMessage
@@ -60,27 +63,28 @@ class ArgumentModification {
   }
 
   captureNode (controller) {
-    return this.insertRecorder(controller, '_tap');
+    return this.insertRecorder(controller.current(), controller.path(), '_tap');
   }
 
-  captureArgument (controller) {
-    return this.insertRecorder(controller, '_rec');
+  captureArgument (currentNode, path) {
+    return this.insertRecorder(currentNode, path, '_rec');
   }
 
   // internal
 
-  insertRecorder (controller, methodName) {
-    const currentNode = controller.current();
+  insertRecorder (currentNode, path, methodName) {
     const receiver = this.argumentRecorderIdent;
-    const path = controller.path();
-    const relativeEsPath = path.slice(this.assertionPath.length);
     const types = new NodeCreator(currentNode);
+    const args = [
+      currentNode
+    ];
+    if (path) {
+      const relativeEsPath = path.slice(this.assertionPath.length);
+      args.push(types.stringLiteral(relativeEsPath.join('/')));
+    }
     const newNode = types.callExpression(
       types.memberExpression(receiver, types.identifier(methodName)),
-      [
-        currentNode,
-        types.stringLiteral(relativeEsPath.join('/'))
-      ]
+      args
     );
     this.argumentModified = true;
     return newNode;

--- a/lib/templates/argument-recorder.json
+++ b/lib/templates/argument-recorder.json
@@ -1014,6 +1014,25 @@
                               "alternate": null
                             },
                             {
+                              "type": "IfStatement",
+                              "test": {
+                                "type": "UnaryExpression",
+                                "operator": "!",
+                                "prefix": true,
+                                "argument": {
+                                  "type": "Identifier",
+                                  "name": "espath"
+                                }
+                              },
+                              "consequent": {
+                                "type": "ReturnStatement",
+                                "argument": {
+                                  "type": "ThisExpression"
+                                }
+                              },
+                              "alternate": null
+                            },
+                            {
                               "type": "VariableDeclaration",
                               "declarations": [
                                 {
@@ -1343,83 +1362,6 @@
                               "alternate": null
                             },
                             {
-                              "type": "ExpressionStatement",
-                              "expression": {
-                                "type": "AssignmentExpression",
-                                "operator": "=",
-                                "left": {
-                                  "type": "MemberExpression",
-                                  "object": {
-                                    "type": "ThisExpression"
-                                  },
-                                  "property": {
-                                    "type": "Identifier",
-                                    "name": "_recorded"
-                                  },
-                                  "computed": false
-                                },
-                                "right": {
-                                  "type": "ObjectExpression",
-                                  "properties": [
-                                    {
-                                      "type": "Property",
-                                      "key": {
-                                        "type": "Identifier",
-                                        "name": "value"
-                                      },
-                                      "value": {
-                                        "type": "Identifier",
-                                        "name": "value"
-                                      },
-                                      "kind": "init",
-                                      "method": false,
-                                      "shorthand": true,
-                                      "computed": false
-                                    },
-                                    {
-                                      "type": "Property",
-                                      "key": {
-                                        "type": "Identifier",
-                                        "name": "logs"
-                                      },
-                                      "value": {
-                                        "type": "CallExpression",
-                                        "callee": {
-                                          "type": "MemberExpression",
-                                          "object": {
-                                            "type": "ArrayExpression",
-                                            "elements": []
-                                          },
-                                          "property": {
-                                            "type": "Identifier",
-                                            "name": "concat"
-                                          },
-                                          "computed": false
-                                        },
-                                        "arguments": [
-                                          {
-                                            "type": "MemberExpression",
-                                            "object": {
-                                              "type": "ThisExpression"
-                                            },
-                                            "property": {
-                                              "type": "Identifier",
-                                              "name": "_logs"
-                                            },
-                                            "computed": false
-                                          }
-                                        ]
-                                      },
-                                      "kind": "init",
-                                      "method": false,
-                                      "shorthand": false,
-                                      "computed": false
-                                    }
-                                  ]
-                                }
-                              }
-                            },
-                            {
                               "type": "ReturnStatement",
                               "argument": {
                                 "type": "ThisExpression"
@@ -1431,6 +1373,96 @@
                         "finalizer": {
                           "type": "BlockStatement",
                           "body": [
+                            {
+                              "type": "IfStatement",
+                              "test": {
+                                "type": "Identifier",
+                                "name": "empowered"
+                              },
+                              "consequent": {
+                                "type": "BlockStatement",
+                                "body": [
+                                  {
+                                    "type": "ExpressionStatement",
+                                    "expression": {
+                                      "type": "AssignmentExpression",
+                                      "operator": "=",
+                                      "left": {
+                                        "type": "MemberExpression",
+                                        "object": {
+                                          "type": "ThisExpression"
+                                        },
+                                        "property": {
+                                          "type": "Identifier",
+                                          "name": "_recorded"
+                                        },
+                                        "computed": false
+                                      },
+                                      "right": {
+                                        "type": "ObjectExpression",
+                                        "properties": [
+                                          {
+                                            "type": "Property",
+                                            "key": {
+                                              "type": "Identifier",
+                                              "name": "value"
+                                            },
+                                            "value": {
+                                              "type": "Identifier",
+                                              "name": "value"
+                                            },
+                                            "kind": "init",
+                                            "method": false,
+                                            "shorthand": true,
+                                            "computed": false
+                                          },
+                                          {
+                                            "type": "Property",
+                                            "key": {
+                                              "type": "Identifier",
+                                              "name": "logs"
+                                            },
+                                            "value": {
+                                              "type": "CallExpression",
+                                              "callee": {
+                                                "type": "MemberExpression",
+                                                "object": {
+                                                  "type": "ArrayExpression",
+                                                  "elements": []
+                                                },
+                                                "property": {
+                                                  "type": "Identifier",
+                                                  "name": "concat"
+                                                },
+                                                "computed": false
+                                              },
+                                              "arguments": [
+                                                {
+                                                  "type": "MemberExpression",
+                                                  "object": {
+                                                    "type": "ThisExpression"
+                                                  },
+                                                  "property": {
+                                                    "type": "Identifier",
+                                                    "name": "_logs"
+                                                  },
+                                                  "computed": false
+                                                }
+                                              ]
+                                            },
+                                            "kind": "init",
+                                            "method": false,
+                                            "shorthand": false,
+                                            "computed": false
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ]
+                              },
+                              "alternate": null
+                            },
                             {
                               "type": "ExpressionStatement",
                               "expression": {

--- a/templates/argument-recorder.js
+++ b/templates/argument-recorder.js
@@ -94,13 +94,14 @@ module.exports = function () {
      * record argument value silently then clear captured logs
      * optionally, proxy block argument then store its result as a Log
      * @param {any} value - actual value of target argument
-     * @param {string} espath - espath of target node in AST
+     * @param {string} [espath] - espath of target node in AST
      * @return {any|ArgumentRecorder} - ArgumentRecorder or actual value of target argument
      */
     _rec (value, espath) {
       const empowered = this._callee && this._callee._empowered;
       try {
         if (!empowered) return value;
+        if (!espath) return this;
 
         const log = {
           value: wrap(value),
@@ -123,13 +124,14 @@ module.exports = function () {
           });
         }
 
-        this._recorded = {
-          value,
-          logs: [].concat(this._logs)
-        };
-
         return this;
       } finally {
+        if (empowered) {
+          this._recorded = {
+            value,
+            logs: [].concat(this._logs)
+          };
+        }
         this._val = value; // actual value of target argument
         this._logs = []; // clear logs
       }

--- a/test/fixtures/ArrayExpression/expected.js
+++ b/test/fixtures/ArrayExpression/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/ArrowFunctionExpression/expected.js
+++ b/test/fixtures/ArrowFunctionExpression/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/AssignmentExpression/expected.js
+++ b/test/fixtures/AssignmentExpression/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/AwaitExpression/expected.js
+++ b/test/fixtures/AwaitExpression/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/BinaryExpression/expected.js
+++ b/test/fixtures/BinaryExpression/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/CallExpression/expected.js
+++ b/test/fixtures/CallExpression/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/ClassExpression/expected.js
+++ b/test/fixtures/ClassExpression/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/ClassScope/expected.js
+++ b/test/fixtures/ClassScope/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/ConditionalExpression/expected.js
+++ b/test/fixtures/ConditionalExpression/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }
@@ -346,7 +350,7 @@ var _ag3 = new _ArgumentRecorder1(assert, _am3, 0);
 var _am4 = _pwmeta1(2, 'assert.equal(foo ? bar : baz, falsy ? truthy : truthy ? anotherFalsy : truthy)', 'path/to/some_test.js', 9);
 var _ag4 = new _ArgumentRecorder1(assert.equal, _am4, 0);
 var _ag5 = new _ArgumentRecorder1(assert.equal, _am4, 1);
-assert(_ag1._rec(_ag1._tap(foo, 'arguments/0/test') ? _ag1._tap(bar, 'arguments/0/consequent') : _ag1._tap(baz, 'arguments/0/alternate'), 'arguments/0'), new _AssertionMessage1(_am1, -1));
-assert(_ag2._rec(_ag2._tap(falsy, 'arguments/0/test') ? _ag2._tap(truthy, 'arguments/0/consequent') : _ag2._tap(truthy, 'arguments/0/alternate/test') ? _ag2._tap(anotherFalsy, 'arguments/0/alternate/consequent') : _ag2._tap(truthy, 'arguments/0/alternate/alternate'), 'arguments/0'), new _AssertionMessage1(_am2, -1));
-assert(_ag3._rec(_ag3._tap(foo(), 'arguments/0/test') ? _ag3._tap(_ag3._tap(bar, 'arguments/0/consequent/object').baz, 'arguments/0/consequent') : _ag3._tap(typeof goo, 'arguments/0/alternate'), 'arguments/0'), new _AssertionMessage1(_am3, -1));
-assert.equal(_ag4._rec(_ag4._tap(foo, 'arguments/0/test') ? _ag4._tap(bar, 'arguments/0/consequent') : _ag4._tap(baz, 'arguments/0/alternate'), 'arguments/0'), _ag5._rec(_ag5._tap(falsy, 'arguments/1/test') ? _ag5._tap(truthy, 'arguments/1/consequent') : _ag5._tap(truthy, 'arguments/1/alternate/test') ? _ag5._tap(anotherFalsy, 'arguments/1/alternate/consequent') : _ag5._tap(truthy, 'arguments/1/alternate/alternate'), 'arguments/1'), new _AssertionMessage1(_am4, -1));
+assert(_ag1._rec(_ag1._tap(foo, 'arguments/0/test') ? _ag1._tap(bar, 'arguments/0/consequent') : _ag1._tap(baz, 'arguments/0/alternate')), new _AssertionMessage1(_am1, -1));
+assert(_ag2._rec(_ag2._tap(falsy, 'arguments/0/test') ? _ag2._tap(truthy, 'arguments/0/consequent') : _ag2._tap(truthy, 'arguments/0/alternate/test') ? _ag2._tap(anotherFalsy, 'arguments/0/alternate/consequent') : _ag2._tap(truthy, 'arguments/0/alternate/alternate')), new _AssertionMessage1(_am2, -1));
+assert(_ag3._rec(_ag3._tap(foo(), 'arguments/0/test') ? _ag3._tap(_ag3._tap(bar, 'arguments/0/consequent/object').baz, 'arguments/0/consequent') : _ag3._tap(typeof goo, 'arguments/0/alternate')), new _AssertionMessage1(_am3, -1));
+assert.equal(_ag4._rec(_ag4._tap(foo, 'arguments/0/test') ? _ag4._tap(bar, 'arguments/0/consequent') : _ag4._tap(baz, 'arguments/0/alternate')), _ag5._rec(_ag5._tap(falsy, 'arguments/1/test') ? _ag5._tap(truthy, 'arguments/1/consequent') : _ag5._tap(truthy, 'arguments/1/alternate/test') ? _ag5._tap(anotherFalsy, 'arguments/1/alternate/consequent') : _ag5._tap(truthy, 'arguments/1/alternate/alternate')), new _AssertionMessage1(_am4, -1));

--- a/test/fixtures/FunctionExpression/expected.js
+++ b/test/fixtures/FunctionExpression/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/Identifier/expected.js
+++ b/test/fixtures/Identifier/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/Literal/expected.js
+++ b/test/fixtures/Literal/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/LogicalExpression/expected.js
+++ b/test/fixtures/LogicalExpression/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/MemberExpression/expected.js
+++ b/test/fixtures/MemberExpression/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/Mocha/expected.js
+++ b/test/fixtures/Mocha/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/NewExpression/expected.js
+++ b/test/fixtures/NewExpression/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/ObjectExpression/expected.js
+++ b/test/fixtures/ObjectExpression/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/Property/expected.js
+++ b/test/fixtures/Property/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/Scopes/expected.js
+++ b/test/fixtures/Scopes/expected.js
@@ -256,6 +256,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -275,12 +277,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/SequenceExpression/expected.js
+++ b/test/fixtures/SequenceExpression/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }
@@ -352,6 +356,6 @@ var _ag6 = new _ArgumentRecorder1(assert, _am6, 0);
 assert((2, 1, 0));
 assert(_ag2._rec((_ag2._tap(foo, 'arguments/0/left/expressions/0'), _ag2._tap(bar, 'arguments/0/left/expressions/1')) === _ag2._tap(baz, 'arguments/0/right'), 'arguments/0'), new _AssertionMessage1(_am2, -1));
 assert(_ag3._rec(toto((_ag3._tap(tata, 'arguments/0/arguments/0/expressions/0'), _ag3._tap(titi, 'arguments/0/arguments/0/expressions/1'))), 'arguments/0'), new _AssertionMessage1(_am3, -1));
-assert(_ag4._rec((_ag4._tap(foo, 'arguments/0/expressions/0'), (_ag4._tap(bar, 'arguments/0/expressions/1/expressions/0'), _ag4._tap(baz, 'arguments/0/expressions/1/expressions/1'))), 'arguments/0'), new _AssertionMessage1(_am4, -1));
-assert(_ag5._rec((((((_ag5._tap(foo, 'arguments/0/expressions/0/expressions/0/expressions/0/expressions/0/expressions/0'), _ag5._tap(bar, 'arguments/0/expressions/0/expressions/0/expressions/0/expressions/0/expressions/1')), _ag5._tap(baz, 'arguments/0/expressions/0/expressions/0/expressions/0/expressions/1')), _ag5._tap(toto, 'arguments/0/expressions/0/expressions/0/expressions/1')), _ag5._tap(tata, 'arguments/0/expressions/0/expressions/1')), _ag5._tap(titi, 'arguments/0/expressions/1')), 'arguments/0'), new _AssertionMessage1(_am5, -1));
-assert(_ag6._rec((_ag6._tap(y = _ag6._tap(x, 'arguments/0/expressions/0/right'), 'arguments/0/expressions/0'), _ag6._tap(z, 'arguments/0/expressions/1')), 'arguments/0'), new _AssertionMessage1(_am6, -1));
+assert(_ag4._rec((_ag4._tap(foo, 'arguments/0/expressions/0'), (_ag4._tap(bar, 'arguments/0/expressions/1/expressions/0'), _ag4._tap(baz, 'arguments/0/expressions/1/expressions/1')))), new _AssertionMessage1(_am4, -1));
+assert(_ag5._rec((((((_ag5._tap(foo, 'arguments/0/expressions/0/expressions/0/expressions/0/expressions/0/expressions/0'), _ag5._tap(bar, 'arguments/0/expressions/0/expressions/0/expressions/0/expressions/0/expressions/1')), _ag5._tap(baz, 'arguments/0/expressions/0/expressions/0/expressions/0/expressions/1')), _ag5._tap(toto, 'arguments/0/expressions/0/expressions/0/expressions/1')), _ag5._tap(tata, 'arguments/0/expressions/0/expressions/1')), _ag5._tap(titi, 'arguments/0/expressions/1'))), new _AssertionMessage1(_am5, -1));
+assert(_ag6._rec((_ag6._tap(y = _ag6._tap(x, 'arguments/0/expressions/0/right'), 'arguments/0/expressions/0'), _ag6._tap(z, 'arguments/0/expressions/1'))), new _AssertionMessage1(_am6, -1));

--- a/test/fixtures/SpreadElement/expected.js
+++ b/test/fixtures/SpreadElement/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/TaggedTemplateExpression/expected.js
+++ b/test/fixtures/TaggedTemplateExpression/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/TemplateLiteral/expected.js
+++ b/test/fixtures/TemplateLiteral/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/UnaryExpression/expected.js
+++ b/test/fixtures/UnaryExpression/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/UpdateExpression/expected.js
+++ b/test/fixtures/UpdateExpression/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/WithoutRequireAssert/expected.js
+++ b/test/fixtures/WithoutRequireAssert/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/WithoutUseStrict/expected.js
+++ b/test/fixtures/WithoutUseStrict/expected.js
@@ -256,6 +256,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -275,12 +277,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/WithoutUseStrictNorRequireAssert/expected.js
+++ b/test/fixtures/WithoutUseStrictNorRequireAssert/expected.js
@@ -256,6 +256,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -275,12 +277,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }

--- a/test/fixtures/YieldExpression/expected.js
+++ b/test/fixtures/YieldExpression/expected.js
@@ -257,6 +257,8 @@ var _ArgumentRecorder1 = function () {
             try {
                 if (!empowered)
                     return value;
+                if (!espath)
+                    return this;
                 const log = {
                     value: wrap(value),
                     espath
@@ -276,12 +278,14 @@ var _ArgumentRecorder1 = function () {
                         }
                     });
                 }
-                this._recorded = {
-                    value,
-                    logs: [].concat(this._logs)
-                };
                 return this;
             } finally {
+                if (empowered) {
+                    this._recorded = {
+                        value,
+                        logs: [].concat(this._logs)
+                    };
+                }
                 this._val = value;
                 this._logs = [];
             }


### PR DESCRIPTION
for example, ConditionalExpression is not a target of value capturing.

when ConditionalExpression appears immediately beneath assert, we should not capture its result.

```js
assert(foo ? bar : baz);
```

result
```
assert(foo ? bar : baz)
       |     |         
       true  null      
```