### PR TITLE
Use `parameter` for declarations, `argument` for actual values

### DIFF
--- a/lib/create-pattern-matchers.js
+++ b/lib/create-pattern-matchers.js
@@ -19,13 +19,13 @@ const createPatternMatchers = (options) => {
       const expression = signatureAst.body[0].expression;
       matcher = new CallMatcher(expression, options);
     }
-    const args = matcher.argumentSignatures().map((sig, idx) => {
-      if (typeof p === 'object' && p !== null && Array.isArray(p.args)) {
-        return Object.assign({}, sig, p.args[idx]);
+    const params = matcher.argumentSignatures().map((sig, idx) => {
+      if (typeof p === 'object' && p !== null && Array.isArray(p.params)) {
+        return Object.assign({}, sig, p.params[idx]);
       }
       return sig;
     });
-    const lastParam = args[args.length - 1];
+    const lastParam = params[params.length - 1];
     if (lastParam.name === 'message' && lastParam.kind === 'optional') {
       lastParam.message = true;
     }
@@ -33,7 +33,7 @@ const createPatternMatchers = (options) => {
       matcher,
       index,
       pattern,
-      args
+      params
     };
   });
 };

--- a/lib/default-options.js
+++ b/lib/default-options.js
@@ -11,10 +11,70 @@ const defaultOptions = () => {
       'assert.notEqual(actual, expected, [message])',
       'assert.strictEqual(actual, expected, [message])',
       'assert.notStrictEqual(actual, expected, [message])',
-      'assert.deepEqual(actual, expected, [message])',
-      'assert.notDeepEqual(actual, expected, [message])',
-      'assert.deepStrictEqual(actual, expected, [message])',
-      'assert.notDeepStrictEqual(actual, expected, [message])'
+      {
+        pattern: 'assert.deepEqual(actual, expected, [message])',
+        params: [
+          { name: 'actual', options: { maxDepth: 2 } },
+          { name: 'expected', options: { maxDepth: 2 } },
+          { name: 'message', message: true }
+        ]
+      },
+      {
+        pattern: 'assert.notDeepEqual(actual, expected, [message])',
+        params: [
+          { name: 'actual', options: { maxDepth: 2 } },
+          { name: 'expected', options: { maxDepth: 2 } },
+          { name: 'message', message: true }
+        ]
+      },
+      {
+        pattern: 'assert.deepStrictEqual(actual, expected, [message])',
+        params: [
+          { name: 'actual', options: { maxDepth: 2 } },
+          { name: 'expected', options: { maxDepth: 2 } },
+          { name: 'message', message: true }
+        ]
+      },
+      {
+        pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
+        params: [
+          { name: 'actual', options: { maxDepth: 2 } },
+          { name: 'expected', options: { maxDepth: 2 } },
+          { name: 'message', message: true }
+        ]
+      },
+      {
+        pattern: 'assert.throws(fn, [error], [message])',
+        params: [
+          { name: 'fn', block: true },
+          { name: 'error', block: true },
+          { name: 'message', message: true }
+        ]
+      },
+      {
+        pattern: 'assert.doesNotThrow(fn, [error], [message])',
+        params: [
+          { name: 'fn', block: true },
+          { name: 'error', block: true },
+          { name: 'message', message: true }
+        ]
+      },
+      {
+        pattern: 'assert.rejects(asyncFn, [error], [message])',
+        params: [
+          { name: 'asyncFn', block: true },
+          { name: 'error', block: true },
+          { name: 'message', message: true }
+        ]
+      },
+      {
+        pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+        params: [
+          { name: 'asyncFn', block: true },
+          { name: 'error', block: true },
+          { name: 'message', message: true }
+        ]
+      }
     ]
   };
 };

--- a/lib/templates/argument-recorder.json
+++ b/lib/templates/argument-recorder.json
@@ -632,7 +632,7 @@
                             "type": "VariableDeclarator",
                             "id": {
                               "type": "Identifier",
-                              "name": "argconf"
+                              "name": "conf"
                             },
                             "init": {
                               "type": "MemberExpression",
@@ -644,7 +644,7 @@
                                 },
                                 "property": {
                                   "type": "Identifier",
-                                  "name": "args"
+                                  "name": "params"
                                 },
                                 "computed": false
                               },
@@ -686,7 +686,7 @@
                                 "type": "MemberExpression",
                                 "object": {
                                   "type": "Identifier",
-                                  "name": "argconf"
+                                  "name": "conf"
                                 },
                                 "property": {
                                   "type": "Identifier",

--- a/templates/argument-recorder.js
+++ b/templates/argument-recorder.js
@@ -30,7 +30,7 @@ module.exports = function () {
      * @property {number} line
      * @property {number} version
      * @property {string} pattern
-     * @property {array} args
+     * @property {array} params
      * @property {boolean} [async] - true if enclosed in async function
      * @property {boolean} [generator] - true if enclosed in generator function
      * @property {string} [ast] - stringified AST
@@ -41,8 +41,8 @@ module.exports = function () {
     /**
      * record argument value and metadata silently
      * @param {function} callee - callee of target argument
-     * @param {AssertionMetadata} am - tranpiler generated metadata for target assertion
-     * @param {number} matchIndex - match index of argument
+     * @param {AssertionMetadata} am - generated metadata for target assertion
+     * @param {number} matchIndex - index of matched parameter
      */
     constructor (callee, am, matchIndex) {
       this._callee = callee;
@@ -51,8 +51,8 @@ module.exports = function () {
       this._recorded = null;
       this._val = null;
       this._idx = matchIndex;
-      const argconf = am.args[matchIndex];
-      this._isBlock = !!argconf.block;
+      const conf = am.params[matchIndex];
+      this._isBlock = !!conf.block;
     }
 
     /**
@@ -70,7 +70,7 @@ module.exports = function () {
     }
 
     /**
-     * @return {any} - recorded actual value of target argument
+     * @return {*} - recorded actual value of target argument
      */
     val () {
       return this._val;
@@ -78,9 +78,9 @@ module.exports = function () {
 
     /**
      * tap capturable node value with its espath then store them as a Log
-     * @param {any} value - actual value of target node
+     * @param {*} value - actual value of target node
      * @param {string} espath - espath of target node in AST
-     * @return {any} - the original value
+     * @return {*} - the original value
      */
     _tap (value, espath) {
       this._logs.push({
@@ -93,9 +93,9 @@ module.exports = function () {
     /**
      * record argument value silently then clear captured logs
      * optionally, proxy block argument then store its result as a Log
-     * @param {any} value - actual value of target argument
+     * @param {*} value - actual value of target argument
      * @param {string} [espath] - espath of target node in AST
-     * @return {any|ArgumentRecorder} - ArgumentRecorder or actual value of target argument
+     * @return {*|ArgumentRecorder} - ArgumentRecorder or actual value of target argument
      */
     _rec (value, espath) {
       const empowered = this._callee && this._callee._empowered;
@@ -139,13 +139,13 @@ module.exports = function () {
 
     /**
      * @typedef {Object} Log
-     * @property {any} value - recorded actual value of target node
+     * @property {*} value - recorded actual value of target node
      * @property {string} espath - espath of target node in AST
      */
 
     /**
      * @typedef {Object} RecordedData
-     * @property {any} value - recorded actual value of target argument
+     * @property {*} value - recorded actual value of target argument
      * @property {Log[]} logs - recorded Logs
      */
 

--- a/templates/assertion-message.js
+++ b/templates/assertion-message.js
@@ -20,7 +20,7 @@ module.exports = function () {
 
     /**
      * @param {AssertionMetadata} am - AssertionMetadata for target assertion
-     * @param {number} matchIndex - match index of argument
+     * @param {number} matchIndex - index of matched parameter
      * @param {string|ArgumentRecorder} [msgOrRec] - maybe enhanced message
      */
     constructor (am, matchIndex, msgOrRec) {
@@ -44,7 +44,7 @@ module.exports = function () {
     }
 
     /**
-     * @return {any} - maybe enhanced message
+     * @return {*} - maybe enhanced message
      */
     val () {
       if (this._msgOrRec && typeof this._msgOrRec.val === 'function') {
@@ -56,13 +56,13 @@ module.exports = function () {
 
     /**
      * @typedef {Object} Log
-     * @property {any} value - recorded actual value of target node
+     * @property {*} value - recorded actual value of target node
      * @property {string} espath - espath of target node in AST
      */
 
     /**
      * @typedef {Object} RecordedData
-     * @property {any} value - recorded actual value of target argument
+     * @property {*} value - recorded actual value of target argument
      * @property {Log[]} logs - recorded Logs
      */
 

--- a/test/espower_option_test.js
+++ b/test/espower_option_test.js
@@ -30,10 +30,70 @@ describe('espower.defaultOptions()', function () {
       'assert.notEqual(actual, expected, [message])',
       'assert.strictEqual(actual, expected, [message])',
       'assert.notStrictEqual(actual, expected, [message])',
-      'assert.deepEqual(actual, expected, [message])',
-      'assert.notDeepEqual(actual, expected, [message])',
-      'assert.deepStrictEqual(actual, expected, [message])',
-      'assert.notDeepStrictEqual(actual, expected, [message])'
+      {
+        pattern: 'assert.deepEqual(actual, expected, [message])',
+        params: [
+          { name: 'actual', options: { maxDepth: 2 } },
+          { name: 'expected', options: { maxDepth: 2 } },
+          { name: 'message', message: true }
+        ]
+      },
+      {
+        pattern: 'assert.notDeepEqual(actual, expected, [message])',
+        params: [
+          { name: 'actual', options: { maxDepth: 2 } },
+          { name: 'expected', options: { maxDepth: 2 } },
+          { name: 'message', message: true }
+        ]
+      },
+      {
+        pattern: 'assert.deepStrictEqual(actual, expected, [message])',
+        params: [
+          { name: 'actual', options: { maxDepth: 2 } },
+          { name: 'expected', options: { maxDepth: 2 } },
+          { name: 'message', message: true }
+        ]
+      },
+      {
+        pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
+        params: [
+          { name: 'actual', options: { maxDepth: 2 } },
+          { name: 'expected', options: { maxDepth: 2 } },
+          { name: 'message', message: true }
+        ]
+      },
+      {
+        pattern: 'assert.throws(fn, [error], [message])',
+        params: [
+          { name: 'fn', block: true },
+          { name: 'error', block: true },
+          { name: 'message', message: true }
+        ]
+      },
+      {
+        pattern: 'assert.doesNotThrow(fn, [error], [message])',
+        params: [
+          { name: 'fn', block: true },
+          { name: 'error', block: true },
+          { name: 'message', message: true }
+        ]
+      },
+      {
+        pattern: 'assert.rejects(asyncFn, [error], [message])',
+        params: [
+          { name: 'asyncFn', block: true },
+          { name: 'error', block: true },
+          { name: 'message', message: true }
+        ]
+      },
+      {
+        pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+        params: [
+          { name: 'asyncFn', block: true },
+          { name: 'error', block: true },
+          { name: 'message', message: true }
+        ]
+      }
     ]);
   });
 });
@@ -108,7 +168,7 @@ describe('instrumentation tests for options', function () {
         ]
       },
       prelude: [
-        "var _pwmeta1=(ptnidx,content,filepath,line,extra)=>{const version=2,patterns=[{pattern:'refute(value)',args:[{index:0,name:'value',kind:'mandatory'}]}];return Object.assign({version,content,filepath,line},extra,patterns[ptnidx]);};"
+        "var _pwmeta1=(ptnidx,content,filepath,line,extra)=>{const version=2,patterns=[{pattern:'refute(value)',params:[{index:0,name:'value',kind:'mandatory'}]}];return Object.assign({version,content,filepath,line},extra,patterns[ptnidx]);};"
       ],
       postlude: [
         "var _am1=_pwmeta1(0,'refute(falsyStr)','path/to/some_test.js',1);",
@@ -126,7 +186,7 @@ describe('instrumentation tests for options', function () {
         ]
       },
       prelude: [
-        "var _pwmeta1=(ptnidx,content,filepath,line,extra)=>{const version=2,patterns=[{pattern:'refute.equal(actual, expected)',args:[{index:0,name:'actual',kind:'mandatory'},{index:1,name:'expected',kind:'mandatory'}]}];return Object.assign({version,content,filepath,line},extra,patterns[ptnidx]);};"
+        "var _pwmeta1=(ptnidx,content,filepath,line,extra)=>{const version=2,patterns=[{pattern:'refute.equal(actual, expected)',params:[{index:0,name:'actual',kind:'mandatory'},{index:1,name:'expected',kind:'mandatory'}]}];return Object.assign({version,content,filepath,line},extra,patterns[ptnidx]);};"
       ],
       postlude: [
         "var _am1=_pwmeta1(0,'refute.equal(foo, bar)','path/to/some_test.js',1);",
@@ -146,7 +206,7 @@ describe('instrumentation tests for options', function () {
         ]
       },
       prelude: [
-        "var _pwmeta1=(ptnidx,content,filepath,line,extra)=>{const version=2,patterns=[{pattern:'browser.assert.element(selection, [message])',args:[{index:0,name:'selection',kind:'mandatory'},{index:1,name:'message',kind:'optional',message:true}]}];return Object.assign({version,content,filepath,line},extra,patterns[ptnidx]);};"
+        "var _pwmeta1=(ptnidx,content,filepath,line,extra)=>{const version=2,patterns=[{pattern:'browser.assert.element(selection, [message])',params:[{index:0,name:'selection',kind:'mandatory'},{index:1,name:'message',kind:'optional',message:true}]}];return Object.assign({version,content,filepath,line},extra,patterns[ptnidx]);};"
       ],
       postlude: [
         "var _am1=_pwmeta1(0,'browser.assert.element(foo)','path/to/some_test.js',1);",
@@ -336,7 +396,7 @@ describe('lineSeparator', function () {
 });
 
 describe('incoming SourceMap support', function () {
-  const metagen = "var _pwmeta1=(ptnidx,content,filepath,line,extra)=>{const version=2,patterns=[{pattern:'assert.equal(actual, expected, [message])',args:[{index:0,name:'actual',kind:'mandatory'},{index:1,name:'expected',kind:'mandatory'},{index:2,name:'message',kind:'optional',message:true}]}];return Object.assign({version,content,filepath,line},extra,patterns[ptnidx]);};";
+  const metagen = "var _pwmeta1=(ptnidx,content,filepath,line,extra)=>{const version=2,patterns=[{pattern:'assert.equal(actual, expected, [message])',params:[{index:0,name:'actual',kind:'mandatory'},{index:1,name:'expected',kind:'mandatory'},{index:2,name:'message',kind:'optional',message:true}]}];return Object.assign({version,content,filepath,line},extra,patterns[ptnidx]);};";
 
   function incomingSourceMapTest (testName, opts) {
     it(testName, function () {
@@ -484,7 +544,7 @@ describe('sourceRoot option', function () {
         sourceFile: config.incomingFilepath
       },
       prelude: [
-        "var _pwmeta1=(ptnidx,content,filepath,line,extra)=>{const version=2,patterns=[{pattern:'assert(value)',args:[{index:0,name:'value',kind:'mandatory'}]}];return Object.assign({version,content,filepath,line},extra,patterns[ptnidx]);};"
+        "var _pwmeta1=(ptnidx,content,filepath,line,extra)=>{const version=2,patterns=[{pattern:'assert(value)',params:[{index:0,name:'value',kind:'mandatory'}]}];return Object.assign({version,content,filepath,line},extra,patterns[ptnidx]);};"
       ],
       postlude: [
         `var _am1=_pwmeta1(0,'assert(falsyStr)','${config.filepathInGeneratedCode}',1);`,

--- a/test/fixtures/ArrayExpression/expected.js
+++ b/test/fixtures/ArrayExpression/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/ArrowFunctionExpression/expected.js
+++ b/test/fixtures/ArrowFunctionExpression/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/AssignmentExpression/expected.js
+++ b/test/fixtures/AssignmentExpression/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/AwaitExpression/expected.js
+++ b/test/fixtures/AwaitExpression/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/BinaryExpression/expected.js
+++ b/test/fixtures/BinaryExpression/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/CallExpression/expected.js
+++ b/test/fixtures/CallExpression/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/ClassExpression/expected.js
+++ b/test/fixtures/ClassExpression/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/ClassScope/expected.js
+++ b/test/fixtures/ClassScope/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/ConditionalExpression/expected.js
+++ b/test/fixtures/ConditionalExpression/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/FunctionExpression/expected.js
+++ b/test/fixtures/FunctionExpression/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/Identifier/expected.js
+++ b/test/fixtures/Identifier/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/Literal/expected.js
+++ b/test/fixtures/Literal/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/LogicalExpression/expected.js
+++ b/test/fixtures/LogicalExpression/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/MemberExpression/expected.js
+++ b/test/fixtures/MemberExpression/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/Mocha/expected.js
+++ b/test/fixtures/Mocha/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/NewExpression/expected.js
+++ b/test/fixtures/NewExpression/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/ObjectExpression/expected.js
+++ b/test/fixtures/ObjectExpression/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/Property/expected.js
+++ b/test/fixtures/Property/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/Scopes/expected.js
+++ b/test/fixtures/Scopes/expected.js
@@ -2,7 +2,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -18,7 +18,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -34,7 +34,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -55,7 +55,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -76,7 +76,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -97,7 +97,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -118,16 +118,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -139,16 +141,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -160,16 +164,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -181,16 +187,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -232,8 +332,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/SequenceExpression/expected.js
+++ b/test/fixtures/SequenceExpression/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/SpreadElement/expected.js
+++ b/test/fixtures/SpreadElement/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/TaggedTemplateExpression/expected.js
+++ b/test/fixtures/TaggedTemplateExpression/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/TemplateLiteral/expected.js
+++ b/test/fixtures/TemplateLiteral/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/UnaryExpression/expected.js
+++ b/test/fixtures/UnaryExpression/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/UpdateExpression/expected.js
+++ b/test/fixtures/UpdateExpression/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/WithoutRequireAssert/expected.js
+++ b/test/fixtures/WithoutRequireAssert/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/WithoutUseStrict/expected.js
+++ b/test/fixtures/WithoutUseStrict/expected.js
@@ -2,7 +2,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -18,7 +18,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -34,7 +34,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -55,7 +55,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -76,7 +76,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -97,7 +97,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -118,16 +118,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -139,16 +141,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -160,16 +164,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -181,16 +187,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -232,8 +332,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/WithoutUseStrictNorRequireAssert/expected.js
+++ b/test/fixtures/WithoutUseStrictNorRequireAssert/expected.js
@@ -2,7 +2,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -18,7 +18,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -34,7 +34,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -55,7 +55,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -76,7 +76,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -97,7 +97,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -118,16 +118,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -139,16 +141,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -160,16 +164,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -181,16 +187,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -232,8 +332,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/fixtures/YieldExpression/expected.js
+++ b/test/fixtures/YieldExpression/expected.js
@@ -3,7 +3,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
     const version = 2, patterns = [
             {
                 pattern: 'assert(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -19,7 +19,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.ok(value, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'value',
@@ -35,7 +35,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.equal(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -56,7 +56,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -77,7 +77,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.strictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -98,7 +98,7 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
@@ -119,16 +119,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -140,16 +142,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -161,16 +165,18 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.deepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 2,
@@ -182,16 +188,110 @@ var _pwmeta1 = (ptnidx, content, filepath, line, extra) => {
             },
             {
                 pattern: 'assert.notDeepStrictEqual(actual, expected, [message])',
-                args: [
+                params: [
                     {
                         index: 0,
                         name: 'actual',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
                     },
                     {
                         index: 1,
                         name: 'expected',
-                        kind: 'mandatory'
+                        kind: 'mandatory',
+                        options: { maxDepth: 2 }
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.throws(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotThrow(fn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'fn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.rejects(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
+                    },
+                    {
+                        index: 2,
+                        name: 'message',
+                        kind: 'optional',
+                        message: true
+                    }
+                ]
+            },
+            {
+                pattern: 'assert.doesNotReject(asyncFn, [error], [message])',
+                params: [
+                    {
+                        index: 0,
+                        name: 'asyncFn',
+                        kind: 'mandatory',
+                        block: true
+                    },
+                    {
+                        index: 1,
+                        name: 'error',
+                        kind: 'optional',
+                        block: true
                     },
                     {
                         index: 2,
@@ -233,8 +333,8 @@ var _ArgumentRecorder1 = function () {
             this._recorded = null;
             this._val = null;
             this._idx = matchIndex;
-            const argconf = am.args[matchIndex];
-            this._isBlock = !!argconf.block;
+            const conf = am.params[matchIndex];
+            this._isBlock = !!conf.block;
         }
         metadata() {
             return this._am;

--- a/test/metadata_test.js
+++ b/test/metadata_test.js
@@ -12,7 +12,7 @@ describe('metadata generator function', () => {
       'const version=2,patterns=[',
       '{',
       "pattern:'assert(value, [message])',",
-      'args:[',
+      'params:[',
       "{index:0,name:'value',kind:'mandatory'},",
       "{index:1,name:'message',kind:'optional',message:true}",
       ']',
@@ -30,14 +30,14 @@ describe('metadata generator function', () => {
       patterns: [
         {
           pattern: 'assert(value, [message])',
-          args: [
+          params: [
             { name: 'value', options: { depth: 2 } },
             { name: 'message', message: true }
           ]
         },
         {
           pattern: 'assert.regex(re, a, b)',
-          args: [
+          params: [
             { name: 're', regex: /^re/ },
             { name: 'a', foo: undefined, bar: null, minus: -1, edge: -0 },
             { name: 'b', 'kebab-case': 'foo-bar' }
@@ -50,14 +50,14 @@ describe('metadata generator function', () => {
       'const version=2,patterns=[',
       '{',
       "pattern:'assert(value, [message])',",
-      'args:[',
+      'params:[',
       "{index:0,name:'value',kind:'mandatory',options:{depth:2}},",
       "{index:1,name:'message',kind:'optional',message:true}",
       ']',
       '},',
       '{',
       "pattern:'assert.regex(re, a, b)',",
-      'args:[',
+      'params:[',
       "{index:0,name:'re',kind:'mandatory',regex:/^re/},",
       "{index:1,name:'a',kind:'mandatory',foo:undefined,bar:null,minus:-1,edge:-0},",
       "{index:2,name:'b',kind:'mandatory','kebab-case':'foo-bar'}",


### PR DESCRIPTION
Naming matters.

Also make it clear to configure output per parameter basis.